### PR TITLE
Change 'Abort' Translation to 'إجهاض'

### DIFF
--- a/test.json
+++ b/test.json
@@ -1,8639 +1,8639 @@
 [
-  {
-    "word": "Abort",
-    "is_checked": false,
-    "translations": [
-      "إجهاض"
-    ]
-  },
-  {
-    "word": "Abortive release",
-    "is_checked": false,
-    "translations": [
-      "انقطاع (شبكي) مجهض"
-    ]
-  },
-  {
-    "word": "Abscissa",
-    "is_checked": false,
-    "translations": [
-      "فاصلة"
-    ]
-  },
-  {
-    "word": "Absolute",
-    "is_checked": false,
-    "translations": [
-      "مطلق(ة) (قيمة)"
-    ]
-  },
-  {
-    "word": "Absolute address",
-    "is_checked": false,
-    "translations": [
-      "عنوان مطلق"
-    ]
-  },
-  {
-    "word": "Absolute path",
-    "is_checked": false,
-    "translations": [
-      "مسار مطلق"
-    ]
-  },
-  {
-    "word": "Absolute pathname",
-    "is_checked": false,
-    "translations": [
-      "اسم مسار مطلق"
-    ]
-  },
-  {
-    "word": "Abstract",
-    "is_checked": false,
-    "translations": [
-      "مجرَّد"
-    ]
-  },
-  {
-    "word": "Abstract class",
-    "is_checked": false,
-    "translations": [
-      "صنف مجرد"
-    ]
-  },
-  {
-    "word": "Abstract data type",
-    "is_checked": false,
-    "translations": [
-      "نوع بيانات مجرد"
-    ]
-  },
-  {
-    "word": "Abstract datatype",
-    "is_checked": false,
-    "translations": [
-      "نوع بيانات مجرد"
-    ]
-  },
-  {
-    "word": "Abstract interpretation",
-    "is_checked": false,
-    "translations": [
-      "تأويل مجرد"
-    ]
-  },
-  {
-    "word": "Abstraction",
-    "is_checked": true,
-    "translations": [
-      "تجريد"
-    ]
-  },
-  {
-    "word": "Abstract machine",
-    "is_checked": false,
-    "translations": [
-      "آلة مجردة"
-    ]
-  },
-  {
-    "word": "Abstract method",
-    "is_checked": false,
-    "translations": [
-      "طريقة مجردة"
-    ]
-  },
-  {
-    "word": "Abstract syntax",
-    "is_checked": false,
-    "translations": [
-      "بنية مجردة"
-    ]
-  },
-  {
-    "word": "Abstract syntax tree",
-    "is_checked": false,
-    "translations": [
-      "شجرة بنية مجردة"
-    ]
-  },
-  {
-    "word": "Accelerated Graphics",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Accelerator",
-    "is_checked": false,
-    "translations": [
-      "مسرِّع"
-    ]
-  },
-  {
-    "word": "Accent",
-    "is_checked": false,
-    "translations": [
-      "حركة"
-    ]
-  },
-  {
-    "word": "Accept",
-    "is_checked": false,
-    "translations": [
-      "قبول"
-    ]
-  },
-  {
-    "word": "Acceptance testing",
-    "is_checked": false,
-    "translations": [
-      "اختبار القبول"
-    ]
-  },
-  {
-    "word": "Access",
-    "is_checked": false,
-    "translations": [
-      "نفاذ"
-    ]
-  },
-  {
-    "word": "Access control list",
-    "is_checked": false,
-    "translations": [
-      "قائمة التحكم بالنفاذ"
-    ]
-  },
-  {
-    "word": "Accessibility",
-    "is_checked": false,
-    "translations": [
-      "إتاحة"
-    ]
-  },
-  {
-    "word": "Accessible",
-    "is_checked": false,
-    "translations": [
-      "مُتَاح"
-    ]
-  },
-  {
-    "word": "Access level",
-    "is_checked": false,
-    "translations": [
-      "مستوى النفاذ"
-    ]
-  },
-  {
-    "word": "Access memory",
-    "is_checked": false,
-    "translations": [
-      "ذاكرة النفاذ"
-    ]
-  },
-  {
-    "word": "Accessory",
-    "is_checked": false,
-    "translations": [
-      "كمالي"
-    ]
-  },
-  {
-    "word": "Access point",
-    "is_checked": false,
-    "translations": [
-      "نقطة العبور"
-    ]
-  },
-  {
-    "word": "Account",
-    "is_checked": false,
-    "translations": [
-      "حساب"
-    ]
-  },
-  {
-    "word": "Accounting management",
-    "is_checked": false,
-    "translations": [
-      "تسيير الحسابات"
-    ]
-  },
-  {
-    "word": "Accumulator",
-    "is_checked": false,
-    "translations": [
-      "مركِّم"
-    ]
-  },
-  {
-    "word": "Accuracy",
-    "is_checked": false,
-    "translations": [
-      "دقة"
-    ]
-  },
-  {
-    "word": "Acknowledgment",
-    "is_checked": false,
-    "translations": [
-      "عرفان :: شكر"
-    ]
-  },
-  {
-    "word": "Acoustic coupler",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Acquire",
-    "is_checked": false,
-    "translations": [
-      "اكتساب"
-    ]
-  },
-  {
-    "word": "Acronym",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Action",
-    "is_checked": false,
-    "translations": [
-      "إجراء"
-    ]
-  },
-  {
-    "word": "Activate",
-    "is_checked": false,
-    "translations": [
-      "تنشيط"
-    ]
-  },
-  {
-    "word": "Active",
-    "is_checked": false,
-    "translations": [
-      "نشِيط"
-    ]
-  },
-  {
-    "word": "Activity",
-    "is_checked": false,
-    "translations": [
-      "نشاط"
-    ]
-  },
-  {
-    "word": "Actor",
-    "is_checked": false,
-    "translations": [
-      "فاعل"
-    ]
-  },
-  {
-    "word": "Actuator",
-    "is_checked": false,
-    "translations": [
-      "مشغّل"
-    ]
-  },
-  {
-    "word": "Adapt",
-    "is_checked": false,
-    "translations": [
-      "تكييف"
-    ]
-  },
-  {
-    "word": "Adapter",
-    "is_checked": false,
-    "translations": [
-      "مكيف"
-    ]
-  },
-  {
-    "word": "Adaptive answering",
-    "is_checked": false,
-    "translations": [
-      "إجابة تكيفية"
-    ]
-  },
-  {
-    "word": "Adaptive learning",
-    "is_checked": false,
-    "translations": [
-      "تعلم تكييفي"
-    ]
-  },
-  {
-    "word": "Adaptive routing",
-    "is_checked": false,
-    "translations": [
-      "توجيه تكيفي"
-    ]
-  },
-  {
-    "word": "Add",
-    "is_checked": false,
-    "translations": [
-      "إضافة"
-    ]
-  },
-  {
-    "word": "Add-in",
-    "is_checked": false,
-    "translations": [
-      "مضاف"
-    ]
-  },
-  {
-    "word": "Add-In",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Additional",
-    "is_checked": false,
-    "translations": [
-      "إضافي"
-    ]
-  },
-  {
-    "word": "Additive",
-    "is_checked": false,
-    "translations": [
-      "انضمامي"
-    ]
-  },
-  {
-    "word": "Addon",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Addon CD",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Address",
-    "is_checked": false,
-    "translations": [
-      "عنوان"
-    ]
-  },
-  {
-    "word": "Address book",
-    "is_checked": false,
-    "translations": [
-      "دفتر عناوين"
-    ]
-  },
-  {
-    "word": "Address bus",
-    "is_checked": false,
-    "translations": [
-      "ناقل عناوين"
-    ]
-  },
-  {
-    "word": "Addressee",
-    "is_checked": false,
-    "translations": [
-      "مرسل إليه"
-    ]
-  },
-  {
-    "word": "Addressing",
-    "is_checked": false,
-    "translations": [
-      "عنونة"
-    ]
-  },
-  {
-    "word": "Adjacency",
-    "is_checked": false,
-    "translations": [
-      "تجاور"
-    ]
-  },
-  {
-    "word": "Adjacent",
-    "is_checked": false,
-    "translations": [
-      "مجاور"
-    ]
-  },
-  {
-    "word": "Adjust",
-    "is_checked": false,
-    "translations": [
-      "ضبط"
-    ]
-  },
-  {
-    "word": "Admin",
-    "is_checked": false,
-    "translations": [
-      "مدير"
-    ]
-  },
-  {
-    "word": "Administration",
-    "is_checked": false,
-    "translations": [
-      "إدارة"
-    ]
-  },
-  {
-    "word": "Administrative",
-    "is_checked": false,
-    "translations": [
-      "إداري"
-    ]
-  },
-  {
-    "word": "Administrator",
-    "is_checked": false,
-    "translations": [
-      "مدير"
-    ]
-  },
-  {
-    "word": "Advance",
-    "is_checked": false,
-    "translations": [
-      "تقدم"
-    ]
-  },
-  {
-    "word": "Advanced",
-    "is_checked": false,
-    "translations": [
-      "متقدم"
-    ]
-  },
-  {
-    "word": "Affix",
-    "is_checked": false,
-    "translations": [
-      "زائدة"
-    ]
-  },
-  {
-    "word": "Agenda",
-    "is_checked": false,
-    "translations": [
-      "مفكرة"
-    ]
-  },
-  {
-    "word": "Agent",
-    "is_checked": false,
-    "translations": [
-      "مفوّض"
-    ]
-  },
-  {
-    "word": "Aggregate",
-    "is_checked": false,
-    "translations": [
-      "مُجمَل"
-    ]
-  },
-  {
-    "word": "Aggregate type",
-    "is_checked": false,
-    "translations": [
-      "نوع مُجمَل"
-    ]
-  },
-  {
-    "word": "Aggregation",
-    "is_checked": false,
-    "translations": [
-      "تجميع"
-    ]
-  },
-  {
-    "word": "Aggregator",
-    "is_checked": false,
-    "translations": [
-      "مُجمِّع"
-    ]
-  },
-  {
-    "word": "Aging",
-    "is_checked": false,
-    "translations": [
-      "تقادم"
-    ]
-  },
-  {
-    "word": "AGP",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Agree",
-    "is_checked": false,
-    "translations": [
-      "موافق"
-    ]
-  },
-  {
-    "word": "Agreement",
-    "is_checked": false,
-    "translations": [
-      "اتفاق"
-    ]
-  },
-  {
-    "word": "Airbrush",
-    "is_checked": false,
-    "translations": [
-      "مرذاذ صباغة"
-    ]
-  },
-  {
-    "word": "Alarm",
-    "is_checked": false,
-    "translations": [
-      "منبه"
-    ]
-  },
-  {
-    "word": "Alarm clock",
-    "is_checked": false,
-    "translations": [
-      "منبه"
-    ]
-  },
-  {
-    "word": "Aleph",
-    "is_checked": false,
-    "translations": [
-      "ألف"
-    ]
-  },
-  {
-    "word": "Alert",
-    "is_checked": false,
-    "translations": [
-      "تنبيه"
-    ]
-  },
-  {
-    "word": "Alert box",
-    "is_checked": false,
-    "translations": [
-      "حوار التنبيه"
-    ]
-  },
-  {
-    "word": "Algebraic data type",
-    "is_checked": false,
-    "translations": [
-      "نوع بيانات جبري"
-    ]
-  },
-  {
-    "word": "Algebraic structure",
-    "is_checked": false,
-    "translations": [
-      "بنية جبرية"
-    ]
-  },
-  {
-    "word": "Algorism",
-    "is_checked": false,
-    "translations": [
-      "خوارزميّة"
-    ]
-  },
-  {
-    "word": "Algorithm",
-    "is_checked": false,
-    "translations": [
-      "خوارزمية"
-    ]
-  },
-  {
-    "word": "Alias",
-    "is_checked": false,
-    "translations": [
-      "كنية"
-    ]
-  },
-  {
-    "word": "Aliasing",
-    "is_checked": false,
-    "translations": [
-      "تسنن"
-    ]
-  },
-  {
-    "word": "Aliasing bug",
-    "is_checked": false,
-    "translations": [
-      "خلل تسنّن"
-    ]
-  },
-  {
-    "word": "Align",
-    "is_checked": false,
-    "translations": [
-      "محاذاة"
-    ]
-  },
-  {
-    "word": "Alignment",
-    "is_checked": false,
-    "translations": [
-      "محاذاة"
-    ]
-  },
-  {
-    "word": "Allocate",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Allow",
-    "is_checked": false,
-    "translations": [
-      "سماح"
-    ]
-  },
-  {
-    "word": "Alpha",
-    "is_checked": false,
-    "translations": [
-      "ألفا"
-    ]
-  },
-  {
-    "word": "Alpha channel",
-    "is_checked": false,
-    "translations": [
-      "قناة ألفا"
-    ]
-  },
-  {
-    "word": "Alphanumeric",
-    "is_checked": false,
-    "translations": [
-      "أبجدي عددي"
-    ]
-  },
-  {
-    "word": "ALSA",
-    "is_checked": false,
-    "translations": [
-      "بنية لينكس الصوتية المتقدمة"
-    ]
-  },
-  {
-    "word": "Alter",
-    "is_checked": false,
-    "translations": [
-      "تغيير"
-    ]
-  },
-  {
-    "word": "Alteration",
-    "is_checked": false,
-    "translations": [
-      "تغيير"
-    ]
-  },
-  {
-    "word": "Alternating",
-    "is_checked": false,
-    "translations": [
-      "تناوبي"
-    ]
-  },
-  {
-    "word": "Alternative",
-    "is_checked": false,
-    "translations": [
-      "بديل"
-    ]
-  },
-  {
-    "word": "Amount",
-    "is_checked": false,
-    "translations": [
-      "كمية"
-    ]
-  },
-  {
-    "word": "Amper",
-    "is_checked": false,
-    "translations": [
-      "أمبير"
-    ]
-  },
-  {
-    "word": "Amplify",
-    "is_checked": false,
-    "translations": [
-      "تضخيم"
-    ]
-  },
-  {
-    "word": "Amplitude",
-    "is_checked": false,
-    "translations": [
-      "سعة"
-    ]
-  },
-  {
-    "word": "Analog",
-    "is_checked": false,
-    "translations": [
-      "نظير"
-    ]
-  },
-  {
-    "word": "Analogue computer",
-    "is_checked": false,
-    "translations": [
-      "حاسوب تماثلي"
-    ]
-  },
-  {
-    "word": "Analysis",
-    "is_checked": false,
-    "translations": [
-      "تحليل"
-    ]
-  },
-  {
-    "word": "Anchor",
-    "is_checked": false,
-    "translations": [
-      "مربط"
-    ]
-  },
-  {
-    "word": "Anchoring",
-    "is_checked": false,
-    "translations": [
-      "إرساء"
-    ]
-  },
-  {
-    "word": "AND",
-    "is_checked": false,
-    "translations": [
-      "و"
-    ]
-  },
-  {
-    "word": "Angle",
-    "is_checked": false,
-    "translations": [
-      "زاوية"
-    ]
-  },
-  {
-    "word": "Angle bracket",
-    "is_checked": false,
-    "translations": [
-      "مكسورة"
-    ]
-  },
-  {
-    "word": "Animate",
-    "is_checked": false,
-    "translations": [
-      "تحريك"
-    ]
-  },
-  {
-    "word": "Animation",
-    "is_checked": false,
-    "translations": [
-      "حركة/رسوم متحركة"
-    ]
-  },
-  {
-    "word": "Anisotropy",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Annotate",
-    "is_checked": false,
-    "translations": [
-      "تعليق"
-    ]
-  },
-  {
-    "word": "Annotation",
-    "is_checked": false,
-    "translations": [
-      "تعليق :: حاشية"
-    ]
-  },
-  {
-    "word": "Announce",
-    "is_checked": false,
-    "translations": [
-      "إعلان"
-    ]
-  },
-  {
-    "word": "Announcement",
-    "is_checked": false,
-    "translations": [
-      "إعلان"
-    ]
-  },
-  {
-    "word": "Anonymous",
-    "is_checked": false,
-    "translations": [
-      "مجهول الاسم"
-    ]
-  },
-  {
-    "word": "Answer mode",
-    "is_checked": false,
-    "translations": [
-      "نمط الإجابة"
-    ]
-  },
-  {
-    "word": "Antialias",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Anti-aliasing",
-    "is_checked": false,
-    "translations": [
-      "إزالة التسنن"
-    ]
-  },
-  {
-    "word": "Antialiasing",
-    "is_checked": false,
-    "translations": [
-      "إزالة التسنن"
-    ]
-  },
-  {
-    "word": "Antisymmetric",
-    "is_checked": false,
-    "translations": [
-      "لا متماثل"
-    ]
-  },
-  {
-    "word": "Anti virus",
-    "is_checked": false,
-    "translations": [
-      "مضاد فيروسات"
-    ]
-  },
-  {
-    "word": "Antivirus",
-    "is_checked": false,
-    "translations": [
-      "مضاد فيروسات"
-    ]
-  },
-  {
-    "word": "Antivirus software",
-    "is_checked": false,
-    "translations": [
-      "برنامج مضاد للفيروسات"
-    ]
-  },
-  {
-    "word": "Anytime algorithm",
-    "is_checked": false,
-    "translations": [
-      "خوارزمية لا وقتية"
-    ]
-  },
-  {
-    "word": "API",
-    "is_checked": false,
-    "translations": [
-      "واجهة برمجة التطبيقات"
-    ]
-  },
-  {
-    "word": "Apostrophe",
-    "is_checked": false,
-    "translations": [
-      "فاصلة عليا"
-    ]
-  },
-  {
-    "word": "Appear",
-    "is_checked": false,
-    "translations": [
-      "ظهور"
-    ]
-  },
-  {
-    "word": "Append",
-    "is_checked": false,
-    "translations": [
-      "إلحاق"
-    ]
-  },
-  {
-    "word": "Applet",
-    "is_checked": false,
-    "translations": [
-      "بريمج"
-    ]
-  },
-  {
-    "word": "Application",
-    "is_checked": false,
-    "translations": [
-      "تطبيق"
-    ]
-  },
-  {
-    "word": "Application Launcher",
-    "is_checked": false,
-    "translations": [
-      "مشغل التطبيق"
-    ]
-  },
-  {
-    "word": "Applix",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Apply",
-    "is_checked": false,
-    "translations": [
-      "تطبيق"
-    ]
-  },
-  {
-    "word": "Appointment",
-    "is_checked": false,
-    "translations": [
-      "موعد"
-    ]
-  },
-  {
-    "word": "Approval",
-    "is_checked": false,
-    "translations": [
-      "إقرار"
-    ]
-  },
-  {
-    "word": "Approve",
-    "is_checked": false,
-    "translations": [
-      "إقرار"
-    ]
-  },
-  {
-    "word": "Approved",
-    "is_checked": false,
-    "translations": [
-      "مصادق عليه"
-    ]
-  },
-  {
-    "word": "Approximate",
-    "is_checked": false,
-    "translations": [
-      "تقريبي"
-    ]
-  },
-  {
-    "word": "Approximation algorithm",
-    "is_checked": false,
-    "translations": [
-      "خوارزمية تقريب"
-    ]
-  },
-  {
-    "word": "Arabisation",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Arabization",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Arbitrary",
-    "is_checked": false,
-    "translations": [
-      "كيفي"
-    ]
-  },
-  {
-    "word": "Arc",
-    "is_checked": false,
-    "translations": [
-      "قوس"
-    ]
-  },
-  {
-    "word": "Architecture",
-    "is_checked": false,
-    "translations": [
-      "بُنية"
-    ]
-  },
-  {
-    "word": "Archive",
-    "is_checked": false,
-    "translations": [
-      "أرشيف"
-    ]
-  },
-  {
-    "word": "Archive site",
-    "is_checked": false,
-    "translations": [
-      "موقع أرشيفي"
-    ]
-  },
-  {
-    "word": "Archiving",
-    "is_checked": false,
-    "translations": [
-      "أرشفة"
-    ]
-  },
-  {
-    "word": "Area",
-    "is_checked": false,
-    "translations": [
-      "منطقة"
-    ]
-  },
-  {
-    "word": "Area grid",
-    "is_checked": false,
-    "translations": [
-      "مربعات المساحة"
-    ]
-  },
-  {
-    "word": "Arena",
-    "is_checked": false,
-    "translations": [
-      "حلبة"
-    ]
-  },
-  {
-    "word": "Argument",
-    "is_checked": false,
-    "translations": [
-      "مُعطى"
-    ]
-  },
-  {
-    "word": "Arity",
-    "is_checked": false,
-    "translations": [
-      "رتبية"
-    ]
-  },
-  {
-    "word": "Arrange",
-    "is_checked": false,
-    "translations": [
-      "ترتيب"
-    ]
-  },
-  {
-    "word": "Arrangement",
-    "is_checked": false,
-    "translations": [
-      "ترتيبة"
-    ]
-  },
-  {
-    "word": "Array",
-    "is_checked": false,
-    "translations": [
-      "مصفوفة"
-    ]
-  },
-  {
-    "word": "Arrow",
-    "is_checked": false,
-    "translations": [
-      "سهم"
-    ]
-  },
-  {
-    "word": "Arrowhead",
-    "is_checked": false,
-    "translations": [
-      "رأس سهم"
-    ]
-  },
-  {
-    "word": "Arrow key",
-    "is_checked": false,
-    "translations": [
-      "مفتاح السهم"
-    ]
-  },
-  {
-    "word": "Article",
-    "is_checked": false,
-    "translations": [
-      "مقالة"
-    ]
-  },
-  {
-    "word": "Artifact",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Artificial intelligence",
-    "is_checked": false,
-    "translations": [
-      "ذكاء اصطناعي"
-    ]
-  },
-  {
-    "word": "Artificial neural network",
-    "is_checked": false,
-    "translations": [
-      "شبكة عصبية اصطناعية"
-    ]
-  },
-  {
-    "word": "Artwork",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Ascender",
-    "is_checked": false,
-    "translations": [
-      "صاعد"
-    ]
-  },
-  {
-    "word": "Ascending",
-    "is_checked": false,
-    "translations": [
-      "تصاعدي"
-    ]
-  },
-  {
-    "word": "Ascending order",
-    "is_checked": false,
-    "translations": [
-      "ترتيب تصاعدي"
-    ]
-  },
-  {
-    "word": "Ascii",
-    "is_checked": false,
-    "translations": [
-      "أسكي"
-    ]
-  },
-  {
-    "word": "Aspect",
-    "is_checked": false,
-    "translations": [
-      "مظهر"
-    ]
-  },
-  {
-    "word": "Aspect-oriented programming",
-    "is_checked": false,
-    "translations": [
-      "برمجة موجهة بالمظاهر"
-    ]
-  },
-  {
-    "word": "Aspect ratio",
-    "is_checked": false,
-    "translations": [
-      "نسبة باعيّة"
-    ]
-  },
-  {
-    "word": "Assembler",
-    "is_checked": false,
-    "translations": [
-      "مُجمِّع"
-    ]
-  },
-  {
-    "word": "Assembly code",
-    "is_checked": false,
-    "translations": [
-      "شفرة تجميع"
-    ]
-  },
-  {
-    "word": "Assembly language",
-    "is_checked": false,
-    "translations": [
-      "لغة تجميعية"
-    ]
-  },
-  {
-    "word": "Asserted",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Assertion",
-    "is_checked": false,
-    "translations": [
-      "توكيد"
-    ]
-  },
-  {
-    "word": "Asset management",
-    "is_checked": false,
-    "translations": [
-      "تسيير الممتلكات"
-    ]
-  },
-  {
-    "word": "Assign",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Assignment",
-    "is_checked": false,
-    "translations": [
-      "إسناد"
-    ]
-  },
-  {
-    "word": "Assignment problem",
-    "is_checked": false,
-    "translations": [
-      "مسألة تعيين (برمجة)"
-    ]
-  },
-  {
-    "word": "Assistant",
-    "is_checked": false,
-    "translations": [
-      "مساعد"
-    ]
-  },
-  {
-    "word": "Associative array",
-    "is_checked": false,
-    "translations": [
-      "مصفوفة ترابطية"
-    ]
-  },
-  {
-    "word": "Associative memory",
-    "is_checked": false,
-    "translations": [
-      "ذاكرة ترابطية"
-    ]
-  },
-  {
-    "word": "Asterisk",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Asymmetric",
-    "is_checked": false,
-    "translations": [
-      "لامُتناظِر"
-    ]
-  },
-  {
-    "word": "Asymmetrical",
-    "is_checked": false,
-    "translations": [
-      "لا تناظري"
-    ]
-  },
-  {
-    "word": "Asymmetrical modulation",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Asynchronous",
-    "is_checked": false,
-    "translations": [
-      "لا تزامني"
-    ]
-  },
-  {
-    "word": "Asynchronous logic",
-    "is_checked": false,
-    "translations": [
-      "منطق لا تزامني"
-    ]
-  },
-  {
-    "word": "Atom",
-    "is_checked": false,
-    "translations": [
-      "ذرة"
-    ]
-  },
-  {
-    "word": "Atomic",
-    "is_checked": false,
-    "translations": [
-      "ذري"
-    ]
-  },
-  {
-    "word": "Atomicity",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "At sign",
-    "is_checked": false,
-    "translations": [
-      "العلامة @"
-    ]
-  },
-  {
-    "word": "Attach",
-    "is_checked": false,
-    "translations": [
-      "إرفاق"
-    ]
-  },
-  {
-    "word": "Attachment",
-    "is_checked": false,
-    "translations": [
-      "مرفق"
-    ]
-  },
-  {
-    "word": "Attempt",
-    "is_checked": false,
-    "translations": [
-      "محاولة"
-    ]
-  },
-  {
-    "word": "Attribute",
-    "is_checked": false,
-    "translations": [
-      "خاصية"
-    ]
-  },
-  {
-    "word": "Audio",
-    "is_checked": false,
-    "translations": [
-      "سمعي"
-    ]
-  },
-  {
-    "word": "Audiographic",
-    "is_checked": false,
-    "translations": [
-      "سمعي تخطيطي"
-    ]
-  },
-  {
-    "word": "Audiographic teleconferencing",
-    "is_checked": false,
-    "translations": [
-      "اجتماع سمعي تخطيطي عن بعد"
-    ]
-  },
-  {
-    "word": "Audit",
-    "is_checked": false,
-    "translations": [
-      "تدقيق"
-    ]
-  },
-  {
-    "word": "Authenticate",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Authentication",
-    "is_checked": false,
-    "translations": [
-      "استيثاق"
-    ]
-  },
-  {
-    "word": "Authentication ticket",
-    "is_checked": false,
-    "translations": [
-      "قسيمة استيثاق"
-    ]
-  },
-  {
-    "word": "Authenticity",
-    "is_checked": false,
-    "translations": [
-      "صحة"
-    ]
-  },
-  {
-    "word": "Authentify",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Author",
-    "is_checked": false,
-    "translations": [
-      "مؤلف"
-    ]
-  },
-  {
-    "word": "Authorization",
-    "is_checked": false,
-    "translations": [
-      "تصريح"
-    ]
-  },
-  {
-    "word": "Authorize",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Auto",
-    "is_checked": false,
-    "translations": [
-      "آلي"
-    ]
-  },
-  {
-    "word": "Autocompletion",
-    "is_checked": false,
-    "translations": [
-      "اتمام تلقائي"
-    ]
-  },
-  {
-    "word": "Autoconfiguration",
-    "is_checked": false,
-    "translations": [
-      "ضبط آلي"
-    ]
-  },
-  {
-    "word": "Autodetect",
-    "is_checked": false,
-    "translations": [
-      "كشف آلي"
-    ]
-  },
-  {
-    "word": "Autofill",
-    "is_checked": false,
-    "translations": [
-      "ملء آلي"
-    ]
-  },
-  {
-    "word": "Autoloader",
-    "is_checked": false,
-    "translations": [
-      "محمّل آلي"
-    ]
-  },
-  {
-    "word": "Automata theory",
-    "is_checked": false,
-    "translations": [
-      "نظرية الآلات الذاتية التشغيل"
-    ]
-  },
-  {
-    "word": "Automated testing",
-    "is_checked": false,
-    "translations": [
-      "اختبار آلي"
-    ]
-  },
-  {
-    "word": "Automatic",
-    "is_checked": false,
-    "translations": [
-      "آلي"
-    ]
-  },
-  {
-    "word": "Automatically",
-    "is_checked": false,
-    "translations": [
-      "آليا"
-    ]
-  },
-  {
-    "word": "Automation",
-    "is_checked": false,
-    "translations": [
-      "تشغيل آلي"
-    ]
-  },
-  {
-    "word": "Automaton",
-    "is_checked": false,
-    "translations": [
-      "مشتغل آلي"
-    ]
-  },
-  {
-    "word": "Autotrace",
-    "is_checked": false,
-    "translations": [
-      "تتبع آلي"
-    ]
-  },
-  {
-    "word": "Auxiliary",
-    "is_checked": false,
-    "translations": [
-      "إضافي"
-    ]
-  },
-  {
-    "word": "Auxiliary storage",
-    "is_checked": false,
-    "translations": [
-      "تخزين إضافي"
-    ]
-  },
-  {
-    "word": "Availability",
-    "is_checked": false,
-    "translations": [
-      "توفر"
-    ]
-  },
-  {
-    "word": "Available",
-    "is_checked": false,
-    "translations": [
-      "متوفر"
-    ]
-  },
-  {
-    "word": "Avatar",
-    "is_checked": false,
-    "translations": [
-      "أفتار"
-    ]
-  },
-  {
-    "word": "Average",
-    "is_checked": false,
-    "translations": [
-      "متوسط"
-    ]
-  },
-  {
-    "word": "Average seek time",
-    "is_checked": false,
-    "translations": [
-      "مدة بحث متوسطة"
-    ]
-  },
-  {
-    "word": "Away",
-    "is_checked": false,
-    "translations": [
-      "غائب"
-    ]
-  },
-  {
-    "word": "Away message",
-    "is_checked": false,
-    "translations": [
-      "رسالة غياب"
-    ]
-  },
-  {
-    "word": "Axial",
-    "is_checked": false,
-    "translations": [
-      "محوري"
-    ]
-  },
-  {
-    "word": "Axiom",
-    "is_checked": false,
-    "translations": [
-      "بديهية"
-    ]
-  },
-  {
-    "word": "Axiomatic semantics",
-    "is_checked": false,
-    "translations": [
-      "دلاليات بديهية"
-    ]
-  },
-  {
-    "word": "Axiomatic set theory",
-    "is_checked": false,
-    "translations": [
-      "نظرية المجموعات البديهية"
-    ]
-  },
-  {
-    "word": "Axis",
-    "is_checked": false,
-    "translations": [
-      "محور"
-    ]
-  },
-  {
-    "word": "Babbleprint",
-    "is_checked": false,
-    "translations": [
-      "بصمة منطوقة"
-    ]
-  },
-  {
-    "word": "Back",
-    "is_checked": false,
-    "translations": [
-      "رجوع"
-    ]
-  },
-  {
-    "word": "Backbone",
-    "is_checked": false,
-    "translations": [
-      "عِماد"
-    ]
-  },
-  {
-    "word": "Backbone site",
-    "is_checked": false,
-    "translations": [
-      "موقع عمادي"
-    ]
-  },
-  {
-    "word": "Back door",
-    "is_checked": false,
-    "translations": [
-      "مدخل سري للنظام"
-    ]
-  },
-  {
-    "word": "Back-end",
-    "is_checked": false,
-    "translations": [
-      "نهاية خلفية"
-    ]
-  },
-  {
-    "word": "Backend",
-    "is_checked": false,
-    "translations": [
-      "منتهى خلفي"
-    ]
-  },
-  {
-    "word": "Background",
-    "is_checked": false,
-    "translations": [
-      "خلفية"
-    ]
-  },
-  {
-    "word": "Background directory",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Background processing",
-    "is_checked": false,
-    "translations": [
-      "معالجة في الخلفية"
-    ]
-  },
-  {
-    "word": "Back link",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Backlog",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Backport",
-    "is_checked": false,
-    "translations": [
-      "حمل عكسي"
-    ]
-  },
-  {
-    "word": "Back-propagation",
-    "is_checked": false,
-    "translations": [
-      "انتشار خلفي"
-    ]
-  },
-  {
-    "word": "Back quote",
-    "is_checked": false,
-    "translations": [
-      "فاصلة عليا مائلة"
-    ]
-  },
-  {
-    "word": "Backronym",
-    "is_checked": false,
-    "translations": [
-      "اسم موجز عكسيا"
-    ]
-  },
-  {
-    "word": "Backside cache",
-    "is_checked": false,
-    "translations": [
-      "مخَبأ خلفي"
-    ]
-  },
-  {
-    "word": "Backslash",
-    "is_checked": false,
-    "translations": [
-      "خط مائل عكسي"
-    ]
-  },
-  {
-    "word": "Backspace",
-    "is_checked": false,
-    "translations": [
-      "فراغ للخلف"
-    ]
-  },
-  {
-    "word": "Backtick",
-    "is_checked": false,
-    "translations": [
-      "فاصلة عليا مائلة"
-    ]
-  },
-  {
-    "word": "Backtrace",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Backtracking",
-    "is_checked": false,
-    "translations": [
-      "تتبع خلفي"
-    ]
-  },
-  {
-    "word": "Backup",
-    "is_checked": false,
-    "translations": [
-      "احتياطي",
-      "نسخ احتياطي",
-      "نسخة احتياطية"
-    ]
-  },
-  {
-    "word": "Backup rotation",
-    "is_checked": false,
-    "translations": [
-      "تعاقب احتياطي"
-    ]
-  },
-  {
-    "word": "Backup software",
-    "is_checked": false,
-    "translations": [
-      "برنامج احتياط"
-    ]
-  },
-  {
-    "word": "Backward analysis",
-    "is_checked": false,
-    "translations": [
-      "تحليل إلى الخلف"
-    ]
-  },
-  {
-    "word": "Backward chaining",
-    "is_checked": false,
-    "translations": [
-      "صَفد إلى الخلف"
-    ]
-  },
-  {
-    "word": "Backward compatibility",
-    "is_checked": false,
-    "translations": [
-      "توافق الإصدارات السابقة"
-    ]
-  },
-  {
-    "word": "Backward compatible",
-    "is_checked": false,
-    "translations": [
-      "متوافق خلفيا"
-    ]
-  },
-  {
-    "word": "Balance",
-    "is_checked": false,
-    "translations": [
-      "توازن"
-    ]
-  },
-  {
-    "word": "Ban",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Bandwidth",
-    "is_checked": false,
-    "translations": [
-      "حيز النطاق"
-    ]
-  },
-  {
-    "word": "Banner",
-    "is_checked": false,
-    "translations": [
-      "لافتة"
-    ]
-  },
-  {
-    "word": "Bar",
-    "is_checked": false,
-    "translations": [
-      "شريط"
-    ]
-  },
-  {
-    "word": "Bareword",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Base",
-    "is_checked": false,
-    "translations": [
-      "أساس :: قاعدة"
-    ]
-  },
-  {
-    "word": "Baseband",
-    "is_checked": false,
-    "translations": [
-      "نطاق أساسي"
-    ]
-  },
-  {
-    "word": "Base class",
-    "is_checked": false,
-    "translations": [
-      "صنف أساسي"
-    ]
-  },
-  {
-    "word": "Baseline",
-    "is_checked": false,
-    "translations": [
-      "خط أساسي"
-    ]
-  },
-  {
-    "word": "Base memory",
-    "is_checked": false,
-    "translations": [
-      "ذاكرة أساسية"
-    ]
-  },
-  {
-    "word": "Basename",
-    "is_checked": false,
-    "translations": [
-      "اسم أساسي"
-    ]
-  },
-  {
-    "word": "Batch",
-    "is_checked": false,
-    "translations": [
-      "دُفعة"
-    ]
-  },
-  {
-    "word": "Batcher",
-    "is_checked": false,
-    "translations": [
-      "معالج دفعات"
-    ]
-  },
-  {
-    "word": "Batch file",
-    "is_checked": false,
-    "translations": [
-      "ملف الدُفعات"
-    ]
-  },
-  {
-    "word": "Batching",
-    "is_checked": false,
-    "translations": [
-      "تدفيع"
-    ]
-  },
-  {
-    "word": "Batch processing",
-    "is_checked": false,
-    "translations": [
-      "معالجة بالدفعات"
-    ]
-  },
-  {
-    "word": "Battery",
-    "is_checked": false,
-    "translations": [
-      "بطارية"
-    ]
-  },
-  {
-    "word": "Baud",
-    "is_checked": false,
-    "translations": [
-      "بود"
-    ]
-  },
-  {
-    "word": "Baud rate",
-    "is_checked": false,
-    "translations": [
-      "معدل الباود"
-    ]
-  },
-  {
-    "word": "Bay",
-    "is_checked": false,
-    "translations": [
-      "فتحة"
-    ]
-  },
-  {
-    "word": "Beam",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Beamer",
-    "is_checked": false,
-    "translations": [
-      "باث"
-    ]
-  },
-  {
-    "word": "Beam search",
-    "is_checked": false,
-    "translations": [
-      "بحث دعاميع"
-    ]
-  },
-  {
-    "word": "Beep",
-    "is_checked": false,
-    "translations": [
-      "صفير"
-    ]
-  },
-  {
-    "word": "Beeper",
-    "is_checked": false,
-    "translations": [
-      "مصفّر"
-    ]
-  },
-  {
-    "word": "Behavior",
-    "is_checked": false,
-    "translations": [
-      "سلوك"
-    ]
-  },
-  {
-    "word": "Bell",
-    "is_checked": false,
-    "translations": [
-      "جرس"
-    ]
-  },
-  {
-    "word": "Bell curve",
-    "is_checked": false,
-    "translations": [
-      "منحنى جرسي"
-    ]
-  },
-  {
-    "word": "Benchmark",
-    "is_checked": false,
-    "translations": [
-      "قياس الأداء"
-    ]
-  },
-  {
-    "word": "Best effort",
-    "is_checked": false,
-    "translations": [
-      "أفضل جهد (خدمة ...)"
-    ]
-  },
-  {
-    "word": "Beta",
-    "is_checked": false,
-    "translations": [
-      "بيتا"
-    ]
-  },
-  {
-    "word": "Beta abstraction",
-    "is_checked": false,
-    "translations": [
-      "تجريد بيتا"
-    ]
-  },
-  {
-    "word": "Beta conversion",
-    "is_checked": false,
-    "translations": [
-      "تحويل بيتا"
-    ]
-  },
-  {
-    "word": "Beta reduction",
-    "is_checked": false,
-    "translations": [
-      "اختزال بيتا"
-    ]
-  },
-  {
-    "word": "Beta testing",
-    "is_checked": false,
-    "translations": [
-      "اختبار بيتا"
-    ]
-  },
-  {
-    "word": "Beta version",
-    "is_checked": false,
-    "translations": [
-      "إصدار بيتا"
-    ]
-  },
-  {
-    "word": "Bibliography",
-    "is_checked": false,
-    "translations": [
-      "المراجع"
-    ]
-  },
-  {
-    "word": "Bidi",
-    "is_checked": false,
-    "translations": [
-      "ثنائية الاتجاه"
-    ]
-  },
-  {
-    "word": "BiDi",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Bidirectional printing",
-    "is_checked": false,
-    "translations": [
-      "طباعة ثنائية الاتجاه"
-    ]
-  },
-  {
-    "word": "Big-endian",
-    "is_checked": false,
-    "translations": [
-      "طرفي-كبير"
-    ]
-  },
-  {
-    "word": "Bijection",
-    "is_checked": false,
-    "translations": [
-      "تقابل"
-    ]
-  },
-  {
-    "word": "Bilinear patch",
-    "is_checked": false,
-    "translations": [
-      "رقعة ثنائية"
-    ]
-  },
-  {
-    "word": "Binary",
-    "is_checked": false,
-    "translations": [
-      "ثنائي"
-    ]
-  },
-  {
-    "word": "Binary coded decimal",
-    "is_checked": false,
-    "translations": [
-      "عشري مرمَّز ثنائيا"
-    ]
-  },
-  {
-    "word": "Binary exponential backoff",
-    "is_checked": false,
-    "translations": [
-      "رقود أسي ثنائي"
-    ]
-  },
-  {
-    "word": "Binary large object",
-    "is_checked": false,
-    "translations": [
-      "كائن ثنائي ضخم"
-    ]
-  },
-  {
-    "word": "Binary package",
-    "is_checked": false,
-    "translations": [
-      "حزمة ثنائية"
-    ]
-  },
-  {
-    "word": "Binary search",
-    "is_checked": false,
-    "translations": [
-      "بحث ثنائي"
-    ]
-  },
-  {
-    "word": "Binary tree",
-    "is_checked": false,
-    "translations": [
-      "شجرة ثنائية"
-    ]
-  },
-  {
-    "word": "Bind",
-    "is_checked": false,
-    "translations": [
-      "ربط"
-    ]
-  },
-  {
-    "word": "Binding",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Binding handle",
-    "is_checked": false,
-    "translations": [
-      "مقبض ارتباط"
-    ]
-  },
-  {
-    "word": "Binding-time analysis",
-    "is_checked": false,
-    "translations": [
-      "تحليل وقت الارتباط"
-    ]
-  },
-  {
-    "word": "BIOS",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Bipolar",
-    "is_checked": false,
-    "translations": [
-      "ثنائي القطب"
-    ]
-  },
-  {
-    "word": "Bit",
-    "is_checked": false,
-    "translations": [
-      "بِتة :: ثنائية :: ذرة"
-    ]
-  },
-  {
-    "word": "Bit block transfer",
-    "is_checked": false,
-    "translations": [
-      "نقل كتلة بت"
-    ]
-  },
-  {
-    "word": "Bit depth",
-    "is_checked": false,
-    "translations": [
-      "عمق البِت"
-    ]
-  },
-  {
-    "word": "Bit gravity",
-    "is_checked": false,
-    "translations": [
-      "جاذبية البِت"
-    ]
-  },
-  {
-    "word": "Bitmap",
-    "is_checked": false,
-    "translations": [
-      "خارطة ثنائية"
-    ]
-  },
-  {
-    "word": "Bitmap display",
-    "is_checked": false,
-    "translations": [
-      "عرض نقطي"
-    ]
-  },
-  {
-    "word": "Bitmap font",
-    "is_checked": false,
-    "translations": [
-      "خط نقطي"
-    ]
-  },
-  {
-    "word": "Bit mask",
-    "is_checked": false,
-    "translations": [
-      "قناع البت"
-    ]
-  },
-  {
-    "word": "Bit pattern",
-    "is_checked": false,
-    "translations": [
-      "متسلسلة ثنائية"
-    ]
-  },
-  {
-    "word": "Bit plane",
-    "is_checked": false,
-    "translations": [
-      "مسطح ثنائية"
-    ]
-  },
-  {
-    "word": "Bit rate",
-    "is_checked": false,
-    "translations": [
-      "معدل البت"
-    ]
-  },
-  {
-    "word": "Bit slice",
-    "is_checked": false,
-    "translations": [
-      "شريحة ثنائيات"
-    ]
-  },
-  {
-    "word": "Bit string",
-    "is_checked": false,
-    "translations": [
-      "سلسلة ثنائيات"
-    ]
-  },
-  {
-    "word": "Bitwise",
-    "is_checked": false,
-    "translations": [
-      "بتّي"
-    ]
-  },
-  {
-    "word": "Bitwise complement",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Blacklist",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Blank",
-    "is_checked": false,
-    "translations": [
-      "فراغ",
-      "فارغ"
-    ]
-  },
-  {
-    "word": "Blend",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Blending",
-    "is_checked": false,
-    "translations": [
-      "مزج"
-    ]
-  },
-  {
-    "word": "Blink",
-    "is_checked": false,
-    "translations": [
-      "وميض"
-    ]
-  },
-  {
-    "word": "Blinking cursor",
-    "is_checked": false,
-    "translations": [
-      "مؤشر نابض"
-    ]
-  },
-  {
-    "word": "Bloat",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Block",
-    "is_checked": false,
-    "translations": [
-      "صدّ :: حظر :: كتلة"
-    ]
-  },
-  {
-    "word": "Block buffer",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Blocked",
-    "is_checked": false,
-    "translations": [
-      "ممنوع"
-    ]
-  },
-  {
-    "word": "Blocked record",
-    "is_checked": false,
-    "translations": [
-      "تسجيلة مكتَّلة"
-    ]
-  },
-  {
-    "word": "Block-structured",
-    "is_checked": false,
-    "translations": [
-      "ذو بنية كُتل"
-    ]
-  },
-  {
-    "word": "Block (unit)",
-    "is_checked": false,
-    "translations": [
-      "كتلة"
-    ]
-  },
-  {
-    "word": "Block (verb)",
-    "is_checked": false,
-    "translations": [
-      "تجميد"
-    ]
-  },
-  {
-    "word": "Blog",
-    "is_checked": false,
-    "translations": [
-      "مدوّنة"
-    ]
-  },
-  {
-    "word": "Blogosphere",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Bluetooth",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Blur",
-    "is_checked": false,
-    "translations": [
-      "ضبابية (رسم) :: عدم وضوح"
-    ]
-  },
-  {
-    "word": "Blu-ray",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Blur image",
-    "is_checked": false,
-    "translations": [
-      "صورة غائمة"
-    ]
-  },
-  {
-    "word": "Board",
-    "is_checked": false,
-    "translations": [
-      "لوحة"
-    ]
-  },
-  {
-    "word": "Body",
-    "is_checked": false,
-    "translations": [
-      "متن"
-    ]
-  },
-  {
-    "word": "Bogon filter",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Bold",
-    "is_checked": false,
-    "translations": [
-      "ثخين"
-    ]
-  },
-  {
-    "word": "Bolt",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Boo",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Book",
-    "is_checked": false,
-    "translations": [
-      "كتاب"
-    ]
-  },
-  {
-    "word": "Book mark",
-    "is_checked": false,
-    "translations": [
-      "علامة موقع"
-    ]
-  },
-  {
-    "word": "Bookmark",
-    "is_checked": false,
-    "translations": [
-      "علامة"
-    ]
-  },
-  {
-    "word": "Boolean",
-    "is_checked": false,
-    "translations": [
-      "منطقي"
-    ]
-  },
-  {
-    "word": "Boot",
-    "is_checked": false,
-    "translations": [
-      "إقلاع"
-    ]
-  },
-  {
-    "word": "Boot block",
-    "is_checked": false,
-    "translations": [
-      "كتلة إقلاع"
-    ]
-  },
-  {
-    "word": "Boot image",
-    "is_checked": false,
-    "translations": [
-      "صورة إقلاع"
-    ]
-  },
-  {
-    "word": "Booting",
-    "is_checked": false,
-    "translations": [
-      "إقلاع"
-    ]
-  },
-  {
-    "word": "Boot loader",
-    "is_checked": false,
-    "translations": [
-      "محمّل الإقلاع"
-    ]
-  },
-  {
-    "word": "Bootloader",
-    "is_checked": false,
-    "translations": [
-      "محمّل إقلاع"
-    ]
-  },
-  {
-    "word": "Bootrom",
-    "is_checked": false,
-    "translations": [
-      "ذقف إقلاع (ذاكرة إقلاع مقروءة فقط)"
-    ]
-  },
-  {
-    "word": "Boot server",
-    "is_checked": false,
-    "translations": [
-      "خادم إقلاع"
-    ]
-  },
-  {
-    "word": "Bootstrap",
-    "is_checked": false,
-    "translations": [
-      "نظام تمهيد تشغيل الكمبيوتر"
-    ]
-  },
-  {
-    "word": "Bootstrap loader",
-    "is_checked": false,
-    "translations": [
-      "محمّل إقلاع"
-    ]
-  },
-  {
-    "word": "Boot virus",
-    "is_checked": false,
-    "translations": [
-      "فايروس إقلاع"
-    ]
-  },
-  {
-    "word": "Border",
-    "is_checked": false,
-    "translations": [
-      "حد"
-    ]
-  },
-  {
-    "word": "Bot",
-    "is_checked": false,
-    "translations": [
-      "آلي"
-    ]
-  },
-  {
-    "word": "Bottom",
-    "is_checked": false,
-    "translations": [
-      "أسفل"
-    ]
-  },
-  {
-    "word": "Bottom-unique",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Bounce",
-    "is_checked": false,
-    "translations": [
-      "يرتد"
-    ]
-  },
-  {
-    "word": "Bounce message",
-    "is_checked": false,
-    "translations": [
-      "رسالة وُثوب"
-    ]
-  },
-  {
-    "word": "Bound",
-    "is_checked": false,
-    "translations": [
-      "مُقَيَّد"
-    ]
-  },
-  {
-    "word": "Boundary scan",
-    "is_checked": false,
-    "translations": [
-      "مسح حدودي"
-    ]
-  },
-  {
-    "word": "Boundary value analysis",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Bounded",
-    "is_checked": false,
-    "translations": [
-      "مُتَنَاه",
-      "مَحْدُود"
-    ]
-  },
-  {
-    "word": "Boundedly complete",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Bounding box",
-    "is_checked": false,
-    "translations": [
-      "مربع إحاطة"
-    ]
-  },
-  {
-    "word": "Bound variable",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Box",
-    "is_checked": false,
-    "translations": [
-      "مربع",
-      "صندوق"
-    ]
-  },
-  {
-    "word": "Boxed comment",
-    "is_checked": false,
-    "translations": [
-      "تعليق مربع"
-    ]
-  },
-  {
-    "word": "Bpp",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Brace",
-    "is_checked": false,
-    "translations": [
-      "حاصرة"
-    ]
-  },
-  {
-    "word": "Bracket",
-    "is_checked": false,
-    "translations": [
-      "قوس"
-    ]
-  },
-  {
-    "word": "Bracket abstraction",
-    "is_checked": false,
-    "translations": [
-      "تجريد الأقواس"
-    ]
-  },
-  {
-    "word": "Braille",
-    "is_checked": false,
-    "translations": [
-      "برايل"
-    ]
-  },
-  {
-    "word": "Branch",
-    "is_checked": false,
-    "translations": [
-      "فرع"
-    ]
-  },
-  {
-    "word": "Branch coverage testing",
-    "is_checked": false,
-    "translations": [
-      "اختبار تغطية التفرّع"
-    ]
-  },
-  {
-    "word": "Branch delay slot",
-    "is_checked": false,
-    "translations": [
-      "فتحة تمهيل التفرّع"
-    ]
-  },
-  {
-    "word": "Branch prediction",
-    "is_checked": false,
-    "translations": [
-      "توقع التفرّع"
-    ]
-  },
-  {
-    "word": "Brand",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Breadth-first search",
-    "is_checked": false,
-    "translations": [
-      "البحث بالعرض أولا"
-    ]
-  },
-  {
-    "word": "Break",
-    "is_checked": false,
-    "translations": [
-      "كسر"
-    ]
-  },
-  {
-    "word": "Break point",
-    "is_checked": false,
-    "translations": [
-      "نقطة انقطاع"
-    ]
-  },
-  {
-    "word": "Breakpoint",
-    "is_checked": false,
-    "translations": [
-      "نقطة المقاطعة"
-    ]
-  },
-  {
-    "word": "Break (program)",
-    "is_checked": false,
-    "translations": [
-      "انقطاع"
-    ]
-  },
-  {
-    "word": "Break statement",
-    "is_checked": false,
-    "translations": [
-      "عبارة انقطاع"
-    ]
-  },
-  {
-    "word": "Bricks",
-    "is_checked": false,
-    "translations": [
-      "طوب"
-    ]
-  },
-  {
-    "word": "Bridge",
-    "is_checked": false,
-    "translations": [
-      "جسر"
-    ]
-  },
-  {
-    "word": "Bridge (noun)",
-    "is_checked": false,
-    "translations": [
-      "جسر"
-    ]
-  },
-  {
-    "word": "Bridge (verb)",
-    "is_checked": false,
-    "translations": [
-      "جَسر"
-    ]
-  },
-  {
-    "word": "Briefcase",
-    "is_checked": false,
-    "translations": [
-      "حقيبة"
-    ]
-  },
-  {
-    "word": "Brightness",
-    "is_checked": false,
-    "translations": [
-      "السطوع"
-    ]
-  },
-  {
-    "word": "Broadband",
-    "is_checked": false,
-    "translations": [
-      "نطاق ترددي واسع",
-      "نطاق واسع"
-    ]
-  },
-  {
-    "word": "Broadcast",
-    "is_checked": false,
-    "translations": [
-      "بث"
-    ]
-  },
-  {
-    "word": "Broadcast quality video",
-    "is_checked": false,
-    "translations": [
-      "مرئية ذات جودة إذاعية"
-    ]
-  },
-  {
-    "word": "Brochure",
-    "is_checked": false,
-    "translations": [
-      "كتيب :: كرّاسة"
-    ]
-  },
-  {
-    "word": "Broken",
-    "is_checked": false,
-    "translations": [
-      "معطوب",
-      "مكسور"
-    ]
-  },
-  {
-    "word": "Broken line",
-    "is_checked": false,
-    "translations": [
-      "خط مقطوع"
-    ]
-  },
-  {
-    "word": "Browse",
-    "is_checked": false,
-    "translations": [
-      "تصفّح"
-    ]
-  },
-  {
-    "word": "Browser",
-    "is_checked": false,
-    "translations": [
-      "متصفح"
-    ]
-  },
-  {
-    "word": "Brush",
-    "is_checked": false,
-    "translations": [
-      "فرشاة"
-    ]
-  },
-  {
-    "word": "Brute force",
-    "is_checked": false,
-    "translations": [
-      "قوة قاسية"
-    ]
-  },
-  {
-    "word": "Brute force attack",
-    "is_checked": false,
-    "translations": [
-      "هجوم بالقوة القاسية"
-    ]
-  },
-  {
-    "word": "BTP",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Bubble",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Buddy",
-    "is_checked": false,
-    "translations": [
-      "صاحب"
-    ]
-  },
-  {
-    "word": "Buffer",
-    "is_checked": false,
-    "translations": [
-      "صِوان"
-    ]
-  },
-  {
-    "word": "Buffered write-through",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Buffering",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Buffer overflow",
-    "is_checked": false,
-    "translations": [
-      "طوفان الصِوان"
-    ]
-  },
-  {
-    "word": "Bug",
-    "is_checked": false,
-    "translations": [
-      "علَّة"
-    ]
-  },
-  {
-    "word": "Bug fix",
-    "is_checked": false,
-    "translations": [
-      "إصلاح خلل"
-    ]
-  },
-  {
-    "word": "Bug fix release",
-    "is_checked": false,
-    "translations": [
-      "إصدار مصلِح"
-    ]
-  },
-  {
-    "word": "Bug tracking system",
-    "is_checked": false,
-    "translations": [
-      "نظام متابعة خلال"
-    ]
-  },
-  {
-    "word": "Build",
-    "is_checked": false,
-    "translations": [
-      "بناء"
-    ]
-  },
-  {
-    "word": "Built-in",
-    "is_checked": false,
-    "translations": [
-      "مضمّن"
-    ]
-  },
-  {
-    "word": "Bullet",
-    "is_checked": false,
-    "translations": [
-      "كرية تعداد",
-      "رصاصة"
-    ]
-  },
-  {
-    "word": "Bulletin Board",
-    "is_checked": false,
-    "translations": [
-      "ساحة نقاش"
-    ]
-  },
-  {
-    "word": "Bulletin board system",
-    "is_checked": false,
-    "translations": [
-      "نظام لوحة النشرات"
-    ]
-  },
-  {
-    "word": "Bullet list",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Bundle",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Bundled",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Burn",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Bus",
-    "is_checked": false,
-    "translations": [
-      "ناقل"
-    ]
-  },
-  {
-    "word": "Bus arbitration",
-    "is_checked": false,
-    "translations": [
-      "حكم النواقل"
-    ]
-  },
-  {
-    "word": "Bus cycle",
-    "is_checked": false,
-    "translations": [
-      "دورة نواقل"
-    ]
-  },
-  {
-    "word": "Bus device",
-    "is_checked": false,
-    "translations": [
-      "جهاز ناقل"
-    ]
-  },
-  {
-    "word": "Bus error",
-    "is_checked": false,
-    "translations": [
-      "خطأ ناقل"
-    ]
-  },
-  {
-    "word": "Business to business",
-    "is_checked": false,
-    "translations": [
-      "متاجرة بين عمل وعمل"
-    ]
-  },
-  {
-    "word": "Bus master",
-    "is_checked": false,
-    "translations": [
-      "رئيس نواقل"
-    ]
-  },
-  {
-    "word": "Bus mastering",
-    "is_checked": false,
-    "translations": [
-      "رئاسة نواقل"
-    ]
-  },
-  {
-    "word": "Bus network",
-    "is_checked": false,
-    "translations": [
-      "شبكة مسروية",
-      "شبكة خطّية"
-    ]
-  },
-  {
-    "word": "Bus priority",
-    "is_checked": false,
-    "translations": [
-      "أولوية نواقل"
-    ]
-  },
-  {
-    "word": "Bus request",
-    "is_checked": false,
-    "translations": [
-      "طلب ناقل"
-    ]
-  },
-  {
-    "word": "Bus sizing",
-    "is_checked": false,
-    "translations": [
-      "تحجيم نواقل"
-    ]
-  },
-  {
-    "word": "Bus watcher",
-    "is_checked": false,
-    "translations": [
-      "مراقب الناقل"
-    ]
-  },
-  {
-    "word": "Busy",
-    "is_checked": false,
-    "translations": [
-      "مشغول"
-    ]
-  },
-  {
-    "word": "Button",
-    "is_checked": false,
-    "translations": [
-      "زر"
-    ]
-  },
-  {
-    "word": "Button binding",
-    "is_checked": false,
-    "translations": [
-      "ربط أزرار"
-    ]
-  },
-  {
-    "word": "Button grab",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Buzz",
-    "is_checked": false,
-    "translations": [
-      "بزبز"
-    ]
-  },
-  {
-    "word": "Bypass",
-    "is_checked": false,
-    "translations": [
-      "تجاوز"
-    ]
-  },
-  {
-    "word": "Byte",
-    "is_checked": false,
-    "translations": [
-      "بايت :: جزئ"
-    ]
-  },
-  {
-    "word": "Byte addressing",
-    "is_checked": false,
-    "translations": [
-      "عنونة ثمانيات"
-    ]
-  },
-  {
-    "word": "Byte-code",
-    "is_checked": false,
-    "translations": [
-      "شفرةٌ ثمانية"
-    ]
-  },
-  {
-    "word": "Byte-code compiler",
-    "is_checked": false,
-    "translations": [
-      "مترجم شفرة ثمانية"
-    ]
-  },
-  {
-    "word": "Byte-code interpreter",
-    "is_checked": false,
-    "translations": [
-      "مؤوّل شفرة ثمانية"
-    ]
-  },
-  {
-    "word": "Byte compiler",
-    "is_checked": false,
-    "translations": [
-      "مترجم شفرة ثمانية"
-    ]
-  },
-  {
-    "word": "Byte order",
-    "is_checked": false,
-    "translations": [
-      "ترتيب ثمانيات"
-    ]
-  },
-  {
-    "word": "C",
-    "is_checked": false,
-    "translations": [
-      "سي"
-    ]
-  },
-  {
-    "word": "Cable",
-    "is_checked": false,
-    "translations": [
-      "كبل"
-    ]
-  },
-  {
-    "word": "Cable modem",
-    "is_checked": false,
-    "translations": [
-      "كبل المودم"
-    ]
-  },
-  {
-    "word": "Cache",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cache block",
-    "is_checked": false,
-    "translations": [
-      "كتلة مَخبأ"
-    ]
-  },
-  {
-    "word": "Cache coherency",
-    "is_checked": false,
-    "translations": [
-      "تماسك مَخبأ"
-    ]
-  },
-  {
-    "word": "Cache conflict",
-    "is_checked": false,
-    "translations": [
-      "تعارض في مَخبأ"
-    ]
-  },
-  {
-    "word": "Cache consistency",
-    "is_checked": false,
-    "translations": [
-      "تماسك مَخبأ"
-    ]
-  },
-  {
-    "word": "Cache controller",
-    "is_checked": false,
-    "translations": [
-      "متحكم مَخبأ"
-    ]
-  },
-  {
-    "word": "Cache hit",
-    "is_checked": false,
-    "translations": [
-      "إصابة مَخبأ"
-    ]
-  },
-  {
-    "word": "Cache lease",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cache line",
-    "is_checked": false,
-    "translations": [
-      "سطر مَخبأ"
-    ]
-  },
-  {
-    "word": "Cache memory",
-    "is_checked": false,
-    "translations": [
-      "مَخبأ"
-    ]
-  },
-  {
-    "word": "Cache miss",
-    "is_checked": false,
-    "translations": [
-      "إخطاء مَخبأ"
-    ]
-  },
-  {
-    "word": "Caching",
-    "is_checked": false,
-    "translations": [
-      "تخزين مؤقت"
-    ]
-  },
-  {
-    "word": "Caching-only",
-    "is_checked": false,
-    "translations": [
-      "خَبء فقط"
-    ]
-  },
-  {
-    "word": "Caching server",
-    "is_checked": false,
-    "translations": [
-      "خادم خَبء",
-      "خادم تخبئة"
-    ]
-  },
-  {
-    "word": "CAD",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Calculate",
-    "is_checked": false,
-    "translations": [
-      "حساب"
-    ]
-  },
-  {
-    "word": "Calculation",
-    "is_checked": false,
-    "translations": [
-      "حساب"
-    ]
-  },
-  {
-    "word": "Calculator",
-    "is_checked": false,
-    "translations": [
-      "حاسبة"
-    ]
-  },
-  {
-    "word": "Calendar",
-    "is_checked": false,
-    "translations": [
-      "تقويم"
-    ]
-  },
-  {
-    "word": "Calibration",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Call",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Callback",
-    "is_checked": false,
-    "translations": [
-      "رد نداء (نظام)"
-    ]
-  },
-  {
-    "word": "Call-by-name",
-    "is_checked": false,
-    "translations": [
-      "نداء بالاسم"
-    ]
-  },
-  {
-    "word": "Call-by-need",
-    "is_checked": false,
-    "translations": [
-      "نداء بالحاجة"
-    ]
-  },
-  {
-    "word": "Call-by-reference",
-    "is_checked": false,
-    "translations": [
-      "نداء بالمرجع"
-    ]
-  },
-  {
-    "word": "Call-by-value",
-    "is_checked": false,
-    "translations": [
-      "نداء بالقيمة"
-    ]
-  },
-  {
-    "word": "Call-by-value-result",
-    "is_checked": false,
-    "translations": [
-      "نداء بنتيجة القيمة"
-    ]
-  },
-  {
-    "word": "Callee",
-    "is_checked": false,
-    "translations": [
-      "منادى"
-    ]
-  },
-  {
-    "word": "Calling convention",
-    "is_checked": false,
-    "translations": [
-      "اتفاق نداء"
-    ]
-  },
-  {
-    "word": "Callout",
-    "is_checked": false,
-    "translations": [
-      "نداء"
-    ]
-  },
-  {
-    "word": "Call-with-current-continuation",
-    "is_checked": false,
-    "translations": [
-      "نداء بالمواصلة الحالية"
-    ]
-  },
-  {
-    "word": "Camera",
-    "is_checked": false,
-    "translations": [
-      "كامرة"
-    ]
-  },
-  {
-    "word": "Cancel",
-    "is_checked": false,
-    "translations": [
-      "إلغاء"
-    ]
-  },
-  {
-    "word": "Candidate key",
-    "is_checked": false,
-    "translations": [
-      "مفتاح مرشَّح"
-    ]
-  },
-  {
-    "word": "Canonical",
-    "is_checked": false,
-    "translations": [
-      "قانوني"
-    ]
-  },
-  {
-    "word": "Canonical name",
-    "is_checked": false,
-    "translations": [
-      "اسم متعارف عليه"
-    ]
-  },
-  {
-    "word": "Canonicity",
-    "is_checked": false,
-    "translations": [
-      "قانونية"
-    ]
-  },
-  {
-    "word": "Canvas",
-    "is_checked": false,
-    "translations": [
-      "رقعة (الرسم)"
-    ]
-  },
-  {
-    "word": "Capability",
-    "is_checked": false,
-    "translations": [
-      "قدرة"
-    ]
-  },
-  {
-    "word": "Capacity",
-    "is_checked": false,
-    "translations": [
-      "سعة"
-    ]
-  },
-  {
-    "word": "Caps",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Caption",
-    "is_checked": false,
-    "translations": [
-      "شرح لوحة"
-    ]
-  },
-  {
-    "word": "Capture",
-    "is_checked": false,
-    "translations": [
-      "التقاط"
-    ]
-  },
-  {
-    "word": "Captured image",
-    "is_checked": false,
-    "translations": [
-      "صورة ملتقطَة"
-    ]
-  },
-  {
-    "word": "Card",
-    "is_checked": false,
-    "translations": [
-      "بطاقة"
-    ]
-  },
-  {
-    "word": "Card cage",
-    "is_checked": false,
-    "translations": [
-      "قفص بطاقات"
-    ]
-  },
-  {
-    "word": "Cardinality",
-    "is_checked": false,
-    "translations": [
-      "رئيسي"
-    ]
-  },
-  {
-    "word": "Cardinal number",
-    "is_checked": false,
-    "translations": [
-      "عدد أصلي"
-    ]
-  },
-  {
-    "word": "Card slot",
-    "is_checked": false,
-    "translations": [
-      "فتحة بطاقات"
-    ]
-  },
-  {
-    "word": "Caret",
-    "is_checked": false,
-    "translations": [
-      "قبعة"
-    ]
-  },
-  {
-    "word": "Carriage return",
-    "is_checked": false,
-    "translations": [
-      "رجوع إلى السطر",
-      "مُرجع إلى السطر (مِحرف)"
-    ]
-  },
-  {
-    "word": "Carrier",
-    "is_checked": false,
-    "translations": [
-      "حامل",
-      "ناقل"
-    ]
-  },
-  {
-    "word": "Carrier scanner",
-    "is_checked": false,
-    "translations": [
-      "ماسحة حوامل"
-    ]
-  },
-  {
-    "word": "Carrier signal",
-    "is_checked": false,
-    "translations": [
-      "إشارة حاملة"
-    ]
-  },
-  {
-    "word": "Cartesian coordinates",
-    "is_checked": false,
-    "translations": [
-      "إحداثيات ديكارتية"
-    ]
-  },
-  {
-    "word": "Cartesian product",
-    "is_checked": false,
-    "translations": [
-      "جداء ديكارتي"
-    ]
-  },
-  {
-    "word": "Cartridge",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cascade",
-    "is_checked": false,
-    "translations": [
-      "تتالي"
-    ]
-  },
-  {
-    "word": "Cascaded list",
-    "is_checked": false,
-    "translations": [
-      "قائمة مدرَّجة"
-    ]
-  },
-  {
-    "word": "Cascading style sheet",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Case",
-    "is_checked": false,
-    "translations": [
-      "حالة"
-    ]
-  },
-  {
-    "word": "Case based reasoning",
-    "is_checked": false,
-    "translations": [
-      "تفكير مبنٍ على الأمثلة"
-    ]
-  },
-  {
-    "word": "Case (font)",
-    "is_checked": false,
-    "translations": [
-      "كبر (حروف)",
-      "حالة (الحرف)"
-    ]
-  },
-  {
-    "word": "Case insensitive",
-    "is_checked": false,
-    "translations": [
-      "غير متأثر بكِبر الحروف"
-    ]
-  },
-  {
-    "word": "Case-sensitive",
-    "is_checked": false,
-    "translations": [
-      "مميِّز لحالة الأحرف"
-    ]
-  },
-  {
-    "word": "Case Sensitive",
-    "is_checked": false,
-    "translations": [
-      "حساس لحالة الحرف"
-    ]
-  },
-  {
-    "word": "Case sensitivity",
-    "is_checked": false,
-    "translations": [
-      "تأثر بكِبر الحروف"
-    ]
-  },
-  {
-    "word": "Case statement",
-    "is_checked": false,
-    "translations": [
-      "عبارةُ حالة"
-    ]
-  },
-  {
-    "word": "Cast",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Casting",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Catalog",
-    "is_checked": false,
-    "translations": [
-      "كتالوج",
-      "مسرد"
-    ]
-  },
-  {
-    "word": "Catch-all",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Catch-all-entry",
-    "is_checked": false,
-    "translations": [
-      "قبض كل المداخل"
-    ]
-  },
-  {
-    "word": "Categories",
-    "is_checked": false,
-    "translations": [
-      "تصنيفات"
-    ]
-  },
-  {
-    "word": "Category",
-    "is_checked": false,
-    "translations": [
-      "فئة"
-    ]
-  },
-  {
-    "word": "Catenet",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cathode ray tube",
-    "is_checked": false,
-    "translations": [
-      "أنبوب حزات كاثودي"
-    ]
-  },
-  {
-    "word": "Cationic cocktail",
-    "is_checked": false,
-    "translations": [
-      "محلول كاتيوني"
-    ]
-  },
-  {
-    "word": "Cause-effect graphing",
-    "is_checked": false,
-    "translations": [
-      "تخطيط سببي مسببي"
-    ]
-  },
-  {
-    "word": "CC",
-    "is_checked": false,
-    "translations": [
-      "(١) نسخة كربونية؛ (٢) مناسخة؛ (٣) يناسخ"
-    ]
-  },
-  {
-    "word": "CD",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "CDE panel",
-    "is_checked": false,
-    "translations": [
-      "لوحة تحكم CDE"
-    ]
-  },
-  {
-    "word": "CD-ROM",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cell",
-    "is_checked": false,
-    "translations": [
-      "خلية"
-    ]
-  },
-  {
-    "word": "Cell encoding",
-    "is_checked": false,
-    "translations": [
-      "ترميز الخلايا"
-    ]
-  },
-  {
-    "word": "Cellphone",
-    "is_checked": false,
-    "translations": [
-      "هاتف خلوي"
-    ]
-  },
-  {
-    "word": "Cellular",
-    "is_checked": false,
-    "translations": [
-      "خلوي"
-    ]
-  },
-  {
-    "word": "Cellular automata",
-    "is_checked": false,
-    "translations": [
-      "مشتغلات آلية خلوية"
-    ]
-  },
-  {
-    "word": "Cellular automaton",
-    "is_checked": false,
-    "translations": [
-      "مشتغل آلي خلوي"
-    ]
-  },
-  {
-    "word": "Cellular multiprocessing",
-    "is_checked": false,
-    "translations": [
-      "معالجة متعددة خلوية"
-    ]
-  },
-  {
-    "word": "Center",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Centered",
-    "is_checked": false,
-    "translations": [
-      "مُوسّط"
-    ]
-  },
-  {
-    "word": "Centimeter",
-    "is_checked": false,
-    "translations": [
-      "سنتيمتر"
-    ]
-  },
-  {
-    "word": "Central arbiter",
-    "is_checked": false,
-    "translations": [
-      "حكم مركزي REMOVE"
-    ]
-  },
-  {
-    "word": "Central office",
-    "is_checked": false,
-    "translations": [
-      "مكتب مركزي"
-    ]
-  },
-  {
-    "word": "Central processing unit",
-    "is_checked": false,
-    "translations": [
-      "وحدة المعالجة المركزية"
-    ]
-  },
-  {
-    "word": "Centum call second",
-    "is_checked": false,
-    "translations": [
-      "مئة ثانية اتصال"
-    ]
-  },
-  {
-    "word": "Cepstrum",
-    "is_checked": false,
-    "translations": [
-      "سبسَتروم"
-    ]
-  },
-  {
-    "word": "Certificate",
-    "is_checked": false,
-    "translations": [
-      "شهادة"
-    ]
-  },
-  {
-    "word": "Certify",
-    "is_checked": false,
-    "translations": [
-      "إشهاد"
-    ]
-  },
-  {
-    "word": "Chad",
-    "is_checked": false,
-    "translations": [
-      "فتات"
-    ]
-  },
-  {
-    "word": "Chad box",
-    "is_checked": false,
-    "translations": [
-      "صندوق فتات"
-    ]
-  },
-  {
-    "word": "Chain",
-    "is_checked": false,
-    "translations": [
-      "سلسلة",
-      "قيد"
-    ]
-  },
-  {
-    "word": "Change",
-    "is_checked": false,
-    "translations": [
-      "تغيير"
-    ]
-  },
-  {
-    "word": "Change management",
-    "is_checked": false,
-    "translations": [
-      "إدارة التغيير"
-    ]
-  },
-  {
-    "word": "Changeover",
-    "is_checked": false,
-    "translations": [
-      "استعداد للتغيير"
-    ]
-  },
-  {
-    "word": "Channel",
-    "is_checked": false,
-    "translations": [
-      "قناة"
-    ]
-  },
-  {
-    "word": "Channel service unit",
-    "is_checked": false,
-    "translations": [
-      "وحدة خدمية قنوية"
-    ]
-  },
-  {
-    "word": "Chaos",
-    "is_checked": false,
-    "translations": [
-      "شواش"
-    ]
-  },
-  {
-    "word": "Chapter",
-    "is_checked": false,
-    "translations": [
-      "فصل"
-    ]
-  },
-  {
-    "word": "Char",
-    "is_checked": false,
-    "translations": [
-      "مِحرف"
-    ]
-  },
-  {
-    "word": "Character",
-    "is_checked": false,
-    "translations": [
-      "مِحرف"
-    ]
-  },
-  {
-    "word": "Character device",
-    "is_checked": false,
-    "translations": [
-      "جهاز مِحرفي"
-    ]
-  },
-  {
-    "word": "Character encoding",
-    "is_checked": false,
-    "translations": [
-      "ترميز الأحرف"
-    ]
-  },
-  {
-    "word": "Character encoding scheme",
-    "is_checked": false,
-    "translations": [
-      "مخطط ترميز محارف"
-    ]
-  },
-  {
-    "word": "Character graphic",
-    "is_checked": false,
-    "translations": [
-      "رسم مِحرفي"
-    ]
-  },
-  {
-    "word": "Characteristic function",
-    "is_checked": false,
-    "translations": [
-      "دالة مميزة"
-    ]
-  },
-  {
-    "word": "Character key",
-    "is_checked": false,
-    "translations": [
-      "مفتاح محرفي"
-    ]
-  },
-  {
-    "word": "Character map",
-    "is_checked": false,
-    "translations": [
-      "خريطة الأحرف"
-    ]
-  },
-  {
-    "word": "Character repertoire",
-    "is_checked": false,
-    "translations": [
-      "مسرد محارف"
-    ]
-  },
-  {
-    "word": "Character set",
-    "is_checked": false,
-    "translations": [
-      "مجموعة أحرف"
-    ]
-  },
-  {
-    "word": "Character set identifier",
-    "is_checked": false,
-    "translations": [
-      "مُعرِّف طقم محارف"
-    ]
-  },
-  {
-    "word": "Character string",
-    "is_checked": false,
-    "translations": [
-      "سلسلة محارف"
-    ]
-  },
-  {
-    "word": "Char cell",
-    "is_checked": false,
-    "translations": [
-      "خلية مِحرف"
-    ]
-  },
-  {
-    "word": "Charityware",
-    "is_checked": false,
-    "translations": [
-      "برنامج خيري"
-    ]
-  },
-  {
-    "word": "Charmap",
-    "is_checked": false,
-    "translations": [
-      "خارطة محارف"
-    ]
-  },
-  {
-    "word": "Charset",
-    "is_checked": false,
-    "translations": [
-      "طقم محارف"
-    ]
-  },
-  {
-    "word": "Chart",
-    "is_checked": false,
-    "translations": [
-      "خُطاطة",
-      "رسم بياني"
-    ]
-  },
-  {
-    "word": "Chase pointers",
-    "is_checked": false,
-    "translations": [
-      "مؤشر تقصّصSINGULAR"
-    ]
-  },
-  {
-    "word": "Chat",
-    "is_checked": false,
-    "translations": [
-      "دردشة"
-    ]
-  },
-  {
-    "word": "Chatchup",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Chat room",
-    "is_checked": false,
-    "translations": [
-      "غرفة دردشة"
-    ]
-  },
-  {
-    "word": "Chat script",
-    "is_checked": false,
-    "translations": [
-      "مخطوط محادثة"
-    ]
-  },
-  {
-    "word": "Check",
-    "is_checked": false,
-    "translations": [
-      "فحص :: تأكُّد"
-    ]
-  },
-  {
-    "word": "Check (a button)",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Check bit",
-    "is_checked": false,
-    "translations": [
-      "بت الفحص"
-    ]
-  },
-  {
-    "word": "Check box",
-    "is_checked": false,
-    "translations": [
-      "صندوق تأشير"
-    ]
-  },
-  {
-    "word": "Checkbox",
-    "is_checked": false,
-    "translations": [
-      "خانة تأشير"
-    ]
-  },
-  {
-    "word": "Checkbox menu",
-    "is_checked": false,
-    "translations": [
-      "قائمة خيارات مربع تأشير"
-    ]
-  },
-  {
-    "word": "Checkered",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Checkout",
-    "is_checked": false,
-    "translations": [
-      "سحب"
-    ]
-  },
-  {
-    "word": "Checkpoint",
-    "is_checked": false,
-    "translations": [
-      "نقطة التحقق"
-    ]
-  },
-  {
-    "word": "Checksum",
-    "is_checked": false,
-    "translations": [
-      "تدقيق المجموع"
-    ]
-  },
-  {
-    "word": "Child",
-    "is_checked": false,
-    "translations": [
-      "بنوي"
-    ]
-  },
-  {
-    "word": "Child directory",
-    "is_checked": false,
-    "translations": [
-      "دليل بنوي"
-    ]
-  },
-  {
-    "word": "Child process",
-    "is_checked": false,
-    "translations": [
-      "عملية بنوية"
-    ]
-  },
-  {
-    "word": "Child record",
-    "is_checked": false,
-    "translations": [
-      "تسجيلة بنوية"
-    ]
-  },
-  {
-    "word": "Child status",
-    "is_checked": false,
-    "translations": [
-      "حالة بنوية"
-    ]
-  },
-  {
-    "word": "Child structure",
-    "is_checked": false,
-    "translations": [
-      "بنية بنوية"
-    ]
-  },
-  {
-    "word": "Child version",
-    "is_checked": false,
-    "translations": [
-      "نسخة بنوية"
-    ]
-  },
-  {
-    "word": "Child window",
-    "is_checked": false,
-    "translations": [
-      "إطار فرعي"
-    ]
-  },
-  {
-    "word": "Chip",
-    "is_checked": false,
-    "translations": [
-      "رقاقة [رقاقات]"
-    ]
-  },
-  {
-    "word": "Chip box",
-    "is_checked": false,
-    "translations": [
-      "صندوق فتات"
-    ]
-  },
-  {
-    "word": "Chip set",
-    "is_checked": false,
-    "translations": [
-      "مجموعة شرائح"
-    ]
-  },
-  {
-    "word": "Chmod",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Choice",
-    "is_checked": false,
-    "translations": [
-      "اختيار"
-    ]
-  },
-  {
-    "word": "Choose",
-    "is_checked": false,
-    "translations": [
-      "اختيار"
-    ]
-  },
-  {
-    "word": "Chooser",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Chroma",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Chroma key",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Chromatic number",
-    "is_checked": false,
-    "translations": [
-      "عدد لوني"
-    ]
-  },
-  {
-    "word": "Chrome",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Chrominance",
-    "is_checked": false,
-    "translations": [
-      "الكروماتية"
-    ]
-  },
-  {
-    "word": "Cipher",
-    "is_checked": false,
-    "translations": [
-      "شيفرة"
-    ]
-  },
-  {
-    "word": "Ciphertext",
-    "is_checked": false,
-    "translations": [
-      "نص مشفّر"
-    ]
-  },
-  {
-    "word": "Circle",
-    "is_checked": false,
-    "translations": [
-      "دائرة"
-    ]
-  },
-  {
-    "word": "Circuit",
-    "is_checked": false,
-    "translations": [
-      "دارة"
-    ]
-  },
-  {
-    "word": "Circuit switched",
-    "is_checked": false,
-    "translations": [
-      "دوريً الإبدال"
-    ]
-  },
-  {
-    "word": "Circuit switching",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Circular buffer",
-    "is_checked": false,
-    "translations": [
-      "مَحفظ دوري"
-    ]
-  },
-  {
-    "word": "Circumflex",
-    "is_checked": false,
-    "translations": [
-      "قبعة"
-    ]
-  },
-  {
-    "word": "Citizen journalism",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Class",
-    "is_checked": false,
-    "translations": [
-      "صنف"
-    ]
-  },
-  {
-    "word": "Class hierarchy",
-    "is_checked": false,
-    "translations": [
-      "سلالة أصناف"
-    ]
-  },
-  {
-    "word": "Classic",
-    "is_checked": false,
-    "translations": [
-      "تقليدي",
-      "اعتيادي"
-    ]
-  },
-  {
-    "word": "Classical logic",
-    "is_checked": false,
-    "translations": [
-      "منطق تقليدي"
-    ]
-  },
-  {
-    "word": "Classification",
-    "is_checked": false,
-    "translations": [
-      "تصنيف"
-    ]
-  },
-  {
-    "word": "Classify",
-    "is_checked": false,
-    "translations": [
-      "تصنيف"
-    ]
-  },
-  {
-    "word": "Class library",
-    "is_checked": false,
-    "translations": [
-      "مكتبة أصناف"
-    ]
-  },
-  {
-    "word": "Class method",
-    "is_checked": false,
-    "translations": [
-      "طريقة صنفية"
-    ]
-  },
-  {
-    "word": "Classpath",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Class variable",
-    "is_checked": false,
-    "translations": [
-      "متغير صنف"
-    ]
-  },
-  {
-    "word": "Clause",
-    "is_checked": false,
-    "translations": [
-      "بند"
-    ]
-  },
-  {
-    "word": "Clean",
-    "is_checked": false,
-    "translations": [
-      "تنظيف",
-      "نظيف"
-    ]
-  },
-  {
-    "word": "Clear",
-    "is_checked": false,
-    "translations": [
-      "محو"
-    ]
-  },
-  {
-    "word": "Clear box testing",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Click",
-    "is_checked": false,
-    "translations": [
-      "نقْر"
-    ]
-  },
-  {
-    "word": "Click (noun)",
-    "is_checked": false,
-    "translations": [
-      "نقرة"
-    ]
-  },
-  {
-    "word": "Click (verb)",
-    "is_checked": false,
-    "translations": [
-      "نقر"
-    ]
-  },
-  {
-    "word": "Client",
-    "is_checked": false,
-    "translations": [
-      "عميل"
-    ]
-  },
-  {
-    "word": "Client-server",
-    "is_checked": false,
-    "translations": [
-      "عميل وخادوم"
-    ]
-  },
-  {
-    "word": "Client-server model",
-    "is_checked": false,
-    "translations": [
-      "نموذج عميل وخادم"
-    ]
-  },
-  {
-    "word": "Client-side",
-    "is_checked": false,
-    "translations": [
-      "من جهة العميل"
-    ]
-  },
-  {
-    "word": "Clip art",
-    "is_checked": false,
-    "translations": [
-      "قصاصة"
-    ]
-  },
-  {
-    "word": "Clipart",
-    "is_checked": false,
-    "translations": [
-      "قصاصة فنية"
-    ]
-  },
-  {
-    "word": "Clip board",
-    "is_checked": false,
-    "translations": [
-      "لوحة قصاصات"
-    ]
-  },
-  {
-    "word": "Clipboard",
-    "is_checked": false,
-    "translations": [
-      "حافظة"
-    ]
-  },
-  {
-    "word": "Clip list",
-    "is_checked": false,
-    "translations": [
-      "قائمة قصاصات"
-    ]
-  },
-  {
-    "word": "Clip mask",
-    "is_checked": false,
-    "translations": [
-      "قناع قصاصة"
-    ]
-  },
-  {
-    "word": "Clipping",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Clipping plane",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Clock",
-    "is_checked": false,
-    "translations": [
-      "ساعة"
-    ]
-  },
-  {
-    "word": "Clock rate",
-    "is_checked": false,
-    "translations": [
-      "سرعة ساعة"
-    ]
-  },
-  {
-    "word": "Clock speed",
-    "is_checked": false,
-    "translations": [
-      "سرعة الميقاتية"
-    ]
-  },
-  {
-    "word": "Clone",
-    "is_checked": false,
-    "translations": [
-      "مستنسخ",
-      "استنساخ"
-    ]
-  },
-  {
-    "word": "Clone device",
-    "is_checked": false,
-    "translations": [
-      "جهاز مستنسخ"
-    ]
-  },
-  {
-    "word": "Close",
-    "is_checked": false,
-    "translations": [
-      "إغلاق"
-    ]
-  },
-  {
-    "word": "Closed set",
-    "is_checked": false,
-    "translations": [
-      "مجموعة مغلقة"
-    ]
-  },
-  {
-    "word": "Closed surface",
-    "is_checked": false,
-    "translations": [
-      "مساحة مغلقة"
-    ]
-  },
-  {
-    "word": "Closed term",
-    "is_checked": false,
-    "translations": [
-      "حد مغلق"
-    ]
-  },
-  {
-    "word": "Close routine",
-    "is_checked": false,
-    "translations": [
-      "وتيرة إغلاق"
-    ]
-  },
-  {
-    "word": "Closure",
-    "is_checked": false,
-    "translations": [
-      "إغلاق"
-    ]
-  },
-  {
-    "word": "Closure conversion",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cloud computing",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Clover key",
-    "is_checked": false,
-    "translations": [
-      "مفتاح نفل"
-    ]
-  },
-  {
-    "word": "Clumsy",
-    "is_checked": false,
-    "translations": [
-      "طائش"
-    ]
-  },
-  {
-    "word": "Cluster",
-    "is_checked": false,
-    "translations": [
-      "خصلة",
-      "عنقود"
-    ]
-  },
-  {
-    "word": "Cluster file",
-    "is_checked": false,
-    "translations": [
-      "ملف حشد"
-    ]
-  },
-  {
-    "word": "Clustering",
-    "is_checked": false,
-    "translations": [
-      "حشد"
-    ]
-  },
-  {
-    "word": "Cluster member",
-    "is_checked": false,
-    "translations": [
-      "عضو حشد"
-    ]
-  },
-  {
-    "word": "Cluster node",
-    "is_checked": false,
-    "translations": [
-      "عقدة خصيلة",
-      "عقدة عنقود"
-    ]
-  },
-  {
-    "word": "Cluster-transport",
-    "is_checked": false,
-    "translations": [
-      "نقل حشد"
-    ]
-  },
-  {
-    "word": "Coalesced sum",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Coarse grain",
-    "is_checked": false,
-    "translations": [
-      "حبً خشن"
-    ]
-  },
-  {
-    "word": "Coax",
-    "is_checked": false,
-    "translations": [
-      "كبل متحد المحور"
-    ]
-  },
-  {
-    "word": "Coaxial",
-    "is_checked": false,
-    "translations": [
-      "متحد المحور"
-    ]
-  },
-  {
-    "word": "Coaxial cable",
-    "is_checked": false,
-    "translations": [
-      "موصل محوري"
-    ]
-  },
-  {
-    "word": "Cocktail shaker sort",
-    "is_checked": false,
-    "translations": [
-      "فرز خلاط"
-    ]
-  },
-  {
-    "word": "Code",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Codebase",
-    "is_checked": false,
-    "translations": [
-      "قاعدة شفرة"
-    ]
-  },
-  {
-    "word": "Codec",
-    "is_checked": false,
-    "translations": [
-      "مرماز"
-    ]
-  },
-  {
-    "word": "Coded character set",
-    "is_checked": false,
-    "translations": [
-      "طقم محارف مرمّز"
-    ]
-  },
-  {
-    "word": "Code division multiplexing",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Code folding",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Code management",
-    "is_checked": false,
-    "translations": [
-      "تسيير شفرة"
-    ]
-  },
-  {
-    "word": "Code position",
-    "is_checked": false,
-    "translations": [
-      "موضع رمز"
-    ]
-  },
-  {
-    "word": "Code (program)",
-    "is_checked": false,
-    "translations": [
-      "شفرة"
-    ]
-  },
-  {
-    "word": "Code segment",
-    "is_checked": false,
-    "translations": [
-      "قطعة شفرة"
-    ]
-  },
-  {
-    "word": "Code (symbol)",
-    "is_checked": false,
-    "translations": [
-      "رمز"
-    ]
-  },
-  {
-    "word": "Code violation",
-    "is_checked": false,
-    "translations": [
-      "خرق (قواعد) الرماز"
-    ]
-  },
-  {
-    "word": "Code walk",
-    "is_checked": false,
-    "translations": [
-      "مراجعة شفرة"
-    ]
-  },
-  {
-    "word": "Codomain",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Coefficient",
-    "is_checked": false,
-    "translations": [
-      "معامل"
-    ]
-  },
-  {
-    "word": "Cognitive architecture",
-    "is_checked": false,
-    "translations": [
-      "عمارة إدراكية"
-    ]
-  },
-  {
-    "word": "Collaboration",
-    "is_checked": false,
-    "translations": [
-      "تعاون"
-    ]
-  },
-  {
-    "word": "Collapse",
-    "is_checked": false,
-    "translations": [
-      "طي"
-    ]
-  },
-  {
-    "word": "Collate",
-    "is_checked": false,
-    "translations": [
-      "رزم"
-    ]
-  },
-  {
-    "word": "Collect",
-    "is_checked": false,
-    "translations": [
-      "التقاط"
-    ]
-  },
-  {
-    "word": "Collection",
-    "is_checked": false,
-    "translations": [
-      "مجموعة"
-    ]
-  },
-  {
-    "word": "Collision",
-    "is_checked": false,
-    "translations": [
-      "تصادم"
-    ]
-  },
-  {
-    "word": "Collision detection",
-    "is_checked": false,
-    "translations": [
-      "كشف تصادمات"
-    ]
-  },
-  {
-    "word": "Colocation",
-    "is_checked": false,
-    "translations": [
-      "توصيل شبكي"
-    ]
-  },
-  {
-    "word": "Colon",
-    "is_checked": false,
-    "translations": [
-      "نقطتان"
-    ]
-  },
-  {
-    "word": "Colophon",
-    "is_checked": false,
-    "translations": [
-      "حرد المتن"
-    ]
-  },
-  {
-    "word": "Color",
-    "is_checked": false,
-    "translations": [
-      "لون"
-    ]
-  },
-  {
-    "word": "Color chooser",
-    "is_checked": false,
-    "translations": [
-      "مخيِّر ألوان"
-    ]
-  },
-  {
-    "word": "Color map",
-    "is_checked": false,
-    "translations": [
-      "مخطط الألوان"
-    ]
-  },
-  {
-    "word": "Colormap",
-    "is_checked": false,
-    "translations": [
-      "مخطط ألوان"
-    ]
-  },
-  {
-    "word": "Color model",
-    "is_checked": false,
-    "translations": [
-      "نموذج ألوان"
-    ]
-  },
-  {
-    "word": "Color saturation",
-    "is_checked": false,
-    "translations": [
-      "إشباع ألوان"
-    ]
-  },
-  {
-    "word": "Colour",
-    "is_checked": false,
-    "translations": [
-      "لون"
-    ]
-  },
-  {
-    "word": "Colour depth",
-    "is_checked": false,
-    "translations": [
-      "عمق ألوان"
-    ]
-  },
-  {
-    "word": "Colour look-up table",
-    "is_checked": false,
-    "translations": [
-      "جدول بحث عن الألوان"
-    ]
-  },
-  {
-    "word": "Colour model",
-    "is_checked": false,
-    "translations": [
-      "نموذج ألوان"
-    ]
-  },
-  {
-    "word": "Colour palette",
-    "is_checked": false,
-    "translations": [
-      "لوحة ألوان"
-    ]
-  },
-  {
-    "word": "Column",
-    "is_checked": false,
-    "translations": [
-      "عمود"
-    ]
-  },
-  {
-    "word": "Column span",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Combination",
-    "is_checked": false,
-    "translations": [
-      "تجميعة"
-    ]
-  },
-  {
-    "word": "Combinator",
-    "is_checked": false,
-    "translations": [
-      "دالة توافقية"
-    ]
-  },
-  {
-    "word": "Combinatory logic",
-    "is_checked": false,
-    "translations": [
-      "منطق توافقي"
-    ]
-  },
-  {
-    "word": "Combo box",
-    "is_checked": false,
-    "translations": [
-      "مربع تحرير وسرد"
-    ]
-  },
-  {
-    "word": "Combobox",
-    "is_checked": false,
-    "translations": [
-      "مربع مركب"
-    ]
-  },
-  {
-    "word": "Comma",
-    "is_checked": false,
-    "translations": [
-      "فاصلة"
-    ]
-  },
-  {
-    "word": "Command",
-    "is_checked": false,
-    "translations": [
-      "أمر"
-    ]
-  },
-  {
-    "word": "Command button",
-    "is_checked": false,
-    "translations": [
-      "زر أمر"
-    ]
-  },
-  {
-    "word": "Command interpreter",
-    "is_checked": false,
-    "translations": [
-      "مؤول أوامر"
-    ]
-  },
-  {
-    "word": "Command key",
-    "is_checked": false,
-    "translations": [
-      "مفتاح أمر"
-    ]
-  },
-  {
-    "word": "Command line",
-    "is_checked": false,
-    "translations": [
-      "سطر الأوامر"
-    ]
-  },
-  {
-    "word": "Commandline",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Command line interface",
-    "is_checked": false,
-    "translations": [
-      "واجهة سطر الأوامر"
-    ]
-  },
-  {
-    "word": "Command-line interpreter",
-    "is_checked": false,
-    "translations": [
-      "مؤول سطر أوامر"
-    ]
-  },
-  {
-    "word": "Command line option",
-    "is_checked": false,
-    "translations": [
-      "خيار سطر أوامر"
-    ]
-  },
-  {
-    "word": "Command line options",
-    "is_checked": false,
-    "translations": [
-      "خيارات سطر الأوامر"
-    ]
-  },
-  {
-    "word": "Command Prompt",
-    "is_checked": false,
-    "translations": [
-      "محث أوامر"
-    ]
-  },
-  {
-    "word": "Comma separated values",
-    "is_checked": false,
-    "translations": [
-      "قيم مفصولة بفواصل"
-    ]
-  },
-  {
-    "word": "Comment",
-    "is_checked": false,
-    "translations": [
-      "تعليق"
-    ]
-  },
-  {
-    "word": "Comment out",
-    "is_checked": false,
-    "translations": [
-      "إزالة تعليق"
-    ]
-  },
-  {
-    "word": "Commercial a",
-    "is_checked": false,
-    "translations": [
-      "علامة عند"
-    ]
-  },
-  {
-    "word": "Commit",
-    "is_checked": false,
-    "translations": [
-      "إيداع"
-    ]
-  },
-  {
-    "word": "Common",
-    "is_checked": false,
-    "translations": [
-      "شائع"
-    ]
-  },
-  {
-    "word": "Common carrier",
-    "is_checked": false,
-    "translations": [
-      "حامل اعتيادي"
-    ]
-  },
-  {
-    "word": "Common factor",
-    "is_checked": false,
-    "translations": [
-      "عامل مشترك"
-    ]
-  },
-  {
-    "word": "Common properties",
-    "is_checked": false,
-    "translations": [
-      "خصائص عامة"
-    ]
-  },
-  {
-    "word": "Communication",
-    "is_checked": false,
-    "translations": [
-      "تواصل"
-    ]
-  },
-  {
-    "word": "Communication system",
-    "is_checked": false,
-    "translations": [
-      "نظام اتصال"
-    ]
-  },
-  {
-    "word": "Compact",
-    "is_checked": false,
-    "translations": [
-      "مُدْمج"
-    ]
-  },
-  {
-    "word": "Compact disc",
-    "is_checked": false,
-    "translations": [
-      "قرص مدمج"
-    ]
-  },
-  {
-    "word": "Compaction",
-    "is_checked": false,
-    "translations": [
-      "ضغط"
-    ]
-  },
-  {
-    "word": "Compactness preserving",
-    "is_checked": false,
-    "translations": [
-      "حفظ تضام"
-    ]
-  },
-  {
-    "word": "Company",
-    "is_checked": false,
-    "translations": [
-      "الشركة"
-    ]
-  },
-  {
-    "word": "Compare",
-    "is_checked": false,
-    "translations": [
-      "مقارنة"
-    ]
-  },
-  {
-    "word": "Compatibility",
-    "is_checked": false,
-    "translations": [
-      "توافق"
-    ]
-  },
-  {
-    "word": "Compatible",
-    "is_checked": false,
-    "translations": [
-      "متوافق"
-    ]
-  },
-  {
-    "word": "Compilation",
-    "is_checked": false,
-    "translations": [
-      "تصريف"
-    ]
-  },
-  {
-    "word": "Compile",
-    "is_checked": false,
-    "translations": [
-      "تصريف"
-    ]
-  },
-  {
-    "word": "Compiler",
-    "is_checked": false,
-    "translations": [
-      "مُصرِّف"
-    ]
-  },
-  {
-    "word": "Compiler compiler",
-    "is_checked": false,
-    "translations": [
-      "مترجم مترجم"
-    ]
-  },
-  {
-    "word": "Complement",
-    "is_checked": false,
-    "translations": [
-      "تكملة"
-    ]
-  },
-  {
-    "word": "Complete",
-    "is_checked": false,
-    "translations": [
-      "تام"
-    ]
-  },
-  {
-    "word": "Complete graph",
-    "is_checked": false,
-    "translations": [
-      "تخطيطة كاملة"
-    ]
-  },
-  {
-    "word": "Complete inference system",
-    "is_checked": false,
-    "translations": [
-      "نظام استنباط كامل"
-    ]
-  },
-  {
-    "word": "Complete lattice",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Complete metric space",
-    "is_checked": false,
-    "translations": [
-      "فضاء متري كامل"
-    ]
-  },
-  {
-    "word": "Completeness",
-    "is_checked": false,
-    "translations": [
-      "كمول"
-    ]
-  },
-  {
-    "word": "Complete partial ordering",
-    "is_checked": false,
-    "translations": [
-      "ترتيب جزئي كامل"
-    ]
-  },
-  {
-    "word": "Complete theory",
-    "is_checked": false,
-    "translations": [
-      "نظرية كمول"
-    ]
-  },
-  {
-    "word": "Complete unification",
-    "is_checked": false,
-    "translations": [
-      "توحيد كامل"
-    ]
-  },
-  {
-    "word": "Complexity",
-    "is_checked": false,
-    "translations": [
-      "تعقّد"
-    ]
-  },
-  {
-    "word": "Complexity analysis",
-    "is_checked": false,
-    "translations": [
-      "تحليل تعقّد"
-    ]
-  },
-  {
-    "word": "Complexity class",
-    "is_checked": false,
-    "translations": [
-      "صنف تعقد"
-    ]
-  },
-  {
-    "word": "Complexity measure",
-    "is_checked": false,
-    "translations": [
-      "قياس تعقد"
-    ]
-  },
-  {
-    "word": "Complex number",
-    "is_checked": false,
-    "translations": [
-      "عدد مركّب"
-    ]
-  },
-  {
-    "word": "Complex programmable logic device",
-    "is_checked": false,
-    "translations": [
-      "جهاز منطقي معقد قابلة للtranslated"
-    ]
-  },
-  {
-    "word": "Component",
-    "is_checked": false,
-    "translations": [
-      "مكوّن"
-    ]
-  },
-  {
-    "word": "Component architecture",
-    "is_checked": false,
-    "translations": [
-      "عمارة مكوّنية"
-    ]
-  },
-  {
-    "word": "Component based development",
-    "is_checked": false,
-    "translations": [
-      "تطوير مبنٍ على المكونات"
-    ]
-  },
-  {
-    "word": "Component video",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Compose",
-    "is_checked": false,
-    "translations": [
-      "تركيب"
-    ]
-  },
-  {
-    "word": "Composite",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Composite cable",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Composite drive",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Composite video",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Composition",
-    "is_checked": false,
-    "translations": [
-      "تركيب"
-    ]
-  },
-  {
-    "word": "Compound command",
-    "is_checked": false,
-    "translations": [
-      "أمر مركب"
-    ]
-  },
-  {
-    "word": "Compound key",
-    "is_checked": false,
-    "translations": [
-      "مفتاح مركَّب"
-    ]
-  },
-  {
-    "word": "Compress",
-    "is_checked": false,
-    "translations": [
-      "ضغط"
-    ]
-  },
-  {
-    "word": "Compressed",
-    "is_checked": false,
-    "translations": [
-      "مضغوط"
-    ]
-  },
-  {
-    "word": "Compressed video",
-    "is_checked": false,
-    "translations": [
-      "مرئية مضغوطة"
-    ]
-  },
-  {
-    "word": "Compressibilty factor",
-    "is_checked": false,
-    "translations": [
-      "عامل الإنضِغاط"
-    ]
-  },
-  {
-    "word": "Compression",
-    "is_checked": false,
-    "translations": [
-      "ضغط"
-    ]
-  },
-  {
-    "word": "Computability theory",
-    "is_checked": false,
-    "translations": [
-      "نظرية تحسيب"
-    ]
-  },
-  {
-    "word": "Computable",
-    "is_checked": false,
-    "translations": [
-      "قابل للتحسيب"
-    ]
-  },
-  {
-    "word": "Computational complexity",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Computational geometry",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Computational learning",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Computational molecular biology",
-    "is_checked": false,
-    "translations": [
-      "بيولوجيا جزيئية حاسوبية"
-    ]
-  },
-  {
-    "word": "Computational organochemistry",
-    "is_checked": false,
-    "translations": [
-      "كيمياء عضوية حاسوبية"
-    ]
-  },
-  {
-    "word": "Compute",
-    "is_checked": false,
-    "translations": [
-      "حساب"
-    ]
-  },
-  {
-    "word": "Computer",
-    "is_checked": false,
-    "translations": [
-      "حاسوب"
-    ]
-  },
-  {
-    "word": "Computer algebra system",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Computer cluster",
-    "is_checked": false,
-    "translations": [
-      "عنقود حاسوبي"
-    ]
-  },
-  {
-    "word": "Computer cookie",
-    "is_checked": false,
-    "translations": [
-      "حلوى حاسوب"
-    ]
-  },
-  {
-    "word": "Computer ethics",
-    "is_checked": false,
-    "translations": [
-      "أخلاقيات حاسوب"
-    ]
-  },
-  {
-    "word": "Computer-generated imagery",
-    "is_checked": false,
-    "translations": [
-      "تصوير مولد بالحاسوب"
-    ]
-  },
-  {
-    "word": "Computer language",
-    "is_checked": false,
-    "translations": [
-      "لغة الحاسوب"
-    ]
-  },
-  {
-    "word": "Computer law",
-    "is_checked": false,
-    "translations": [
-      "قانون حاسوب"
-    ]
-  },
-  {
-    "word": "Computer literacy",
-    "is_checked": false,
-    "translations": [
-      "إلمام بالحاسوب"
-    ]
-  },
-  {
-    "word": "Computer network",
-    "is_checked": false,
-    "translations": [
-      "شبكة حواسب"
-    ]
-  },
-  {
-    "word": "Computer program",
-    "is_checked": false,
-    "translations": [
-      "برنامج حاسوب"
-    ]
-  },
-  {
-    "word": "Computer security",
-    "is_checked": false,
-    "translations": [
-      "أمن الكمبيوتر"
-    ]
-  },
-  {
-    "word": "Computer virus",
-    "is_checked": false,
-    "translations": [
-      "فيروس حاسوبي"
-    ]
-  },
-  {
-    "word": "Computer vision",
-    "is_checked": false,
-    "translations": [
-      "بصر حاسوبي"
-    ]
-  },
-  {
-    "word": "Compute server",
-    "is_checked": false,
-    "translations": [
-      "خادم حساب"
-    ]
-  },
-  {
-    "word": "Computing",
-    "is_checked": false,
-    "translations": [
-      "حوسبة"
-    ]
-  },
-  {
-    "word": "Computron",
-    "is_checked": false,
-    "translations": [
-      "حاسوبون"
-    ]
-  },
-  {
-    "word": "Concatenate",
-    "is_checked": false,
-    "translations": [
-      "لمّ"
-    ]
-  },
-  {
-    "word": "Concatenated key",
-    "is_checked": false,
-    "translations": [
-      "مفتاح ملموم"
-    ]
-  },
-  {
-    "word": "Concentrator",
-    "is_checked": false,
-    "translations": [
-      "مركِّز"
-    ]
-  },
-  {
-    "word": "Conceptualisation",
-    "is_checked": false,
-    "translations": [
-      "مفهمة"
-    ]
-  },
-  {
-    "word": "Concrete class",
-    "is_checked": false,
-    "translations": [
-      "فئة محددة"
-    ]
-  },
-  {
-    "word": "Concrete syntax",
-    "is_checked": false,
-    "translations": [
-      "نحو مادي"
-    ]
-  },
-  {
-    "word": "Concurrency",
-    "is_checked": false,
-    "translations": [
-      "تزامن"
-    ]
-  },
-  {
-    "word": "Concurrent",
-    "is_checked": false,
-    "translations": [
-      "مرافق",
-      "متزامن"
-    ]
-  },
-  {
-    "word": "Concurrent processing",
-    "is_checked": false,
-    "translations": [
-      "معالجة منافسة"
-    ]
-  },
-  {
-    "word": "Condense",
-    "is_checked": false,
-    "translations": [
-      "تكثيف"
-    ]
-  },
-  {
-    "word": "Condensed",
-    "is_checked": false,
-    "translations": [
-      "مكثف",
-      "موجز"
-    ]
-  },
-  {
-    "word": "Condition",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Condition out",
-    "is_checked": false,
-    "translations": [
-      "تفريغ شرط"
-    ]
-  },
-  {
-    "word": "Conduit",
-    "is_checked": false,
-    "translations": [
-      "مجرى"
-    ]
-  },
-  {
-    "word": "Cone",
-    "is_checked": false,
-    "translations": [
-      "مخروط"
-    ]
-  },
-  {
-    "word": "Confidence test",
-    "is_checked": false,
-    "translations": [
-      "اختبار ثقة"
-    ]
-  },
-  {
-    "word": "Confidential",
-    "is_checked": false,
-    "translations": [
-      "سرّي"
-    ]
-  },
-  {
-    "word": "Configuration",
-    "is_checked": false,
-    "translations": [
-      "تضبيط"
-    ]
-  },
-  {
-    "word": "Configuration item",
-    "is_checked": false,
-    "translations": [
-      "عنصر تشكيل"
-    ]
-  },
-  {
-    "word": "Configuration management",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Configuration programming",
-    "is_checked": false,
-    "translations": [
-      "برمجة تشكيل"
-    ]
-  },
-  {
-    "word": "Configure",
-    "is_checked": false,
-    "translations": [
-      "ضبط"
-    ]
-  },
-  {
-    "word": "Confirm",
-    "is_checked": false,
-    "translations": [
-      "تأكيد"
-    ]
-  },
-  {
-    "word": "Confirmation",
-    "is_checked": false,
-    "translations": [
-      "تأكيد"
-    ]
-  },
-  {
-    "word": "Conflation",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Conflict",
-    "is_checked": false,
-    "translations": [
-      "تضارب",
-      "تناقض"
-    ]
-  },
-  {
-    "word": "Congestion",
-    "is_checked": false,
-    "translations": [
-      "احتقان"
-    ]
-  },
-  {
-    "word": "Conjunction",
-    "is_checked": false,
-    "translations": [
-      "اقتران"
-    ]
-  },
-  {
-    "word": "Connect",
-    "is_checked": false,
-    "translations": [
-      "اتصال"
-    ]
-  },
-  {
-    "word": "Connected graph",
-    "is_checked": false,
-    "translations": [
-      "مبيان متصل"
-    ]
-  },
-  {
-    "word": "Connected subgraph",
-    "is_checked": false,
-    "translations": [
-      "مبيان فرعي متصل"
-    ]
-  },
-  {
-    "word": "Connection",
-    "is_checked": false,
-    "translations": [
-      "اتصال"
-    ]
-  },
-  {
-    "word": "Connectionless protocol",
-    "is_checked": false,
-    "translations": [
-      "ميفاق بدون اتصال"
-    ]
-  },
-  {
-    "word": "Connection-oriented",
-    "is_checked": false,
-    "translations": [
-      "موجّه بالاتصال"
-    ]
-  },
-  {
-    "word": "Connection-oriented network service",
-    "is_checked": false,
-    "translations": [
-      "خدمة شبكية موجّهة بالاتصال"
-    ]
-  },
-  {
-    "word": "Connection pool",
-    "is_checked": false,
-    "translations": [
-      "مَجمع اتصالات"
-    ]
-  },
-  {
-    "word": "Connective",
-    "is_checked": false,
-    "translations": [
-      "رابط",
-      "إتصالي"
-    ]
-  },
-  {
-    "word": "Connectors",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Conservative evaluation",
-    "is_checked": false,
-    "translations": [
-      "تقييم محافظ"
-    ]
-  },
-  {
-    "word": "Consistently complete",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Console",
-    "is_checked": false,
-    "translations": [
-      "كونسول"
-    ]
-  },
-  {
-    "word": "Consolidate",
-    "is_checked": false,
-    "translations": [
-      "توطيد",
-      "تدعيم"
-    ]
-  },
-  {
-    "word": "Constant",
-    "is_checked": false,
-    "translations": [
-      "ثابت"
-    ]
-  },
-  {
-    "word": "Constant angular velocity",
-    "is_checked": false,
-    "translations": [
-      "سرعة زاوية ثابتة"
-    ]
-  },
-  {
-    "word": "Constant applicative form",
-    "is_checked": false,
-    "translations": [
-      "شكل تطبيقي ثابت"
-    ]
-  },
-  {
-    "word": "Constant folding",
-    "is_checked": false,
-    "translations": [
-      "طي ثابت"
-    ]
-  },
-  {
-    "word": "Constant linear velocity",
-    "is_checked": false,
-    "translations": [
-      "سرعة خطية ثابتة"
-    ]
-  },
-  {
-    "word": "Constant mapping",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Constraint",
-    "is_checked": false,
-    "translations": [
-      "قيد",
-      "قسْر"
-    ]
-  },
-  {
-    "word": "Constraint functional programming",
-    "is_checked": false,
-    "translations": [
-      "برمجة وظيفية قيدية"
-    ]
-  },
-  {
-    "word": "Constraint satisfaction",
-    "is_checked": false,
-    "translations": [
-      "إرضاء قيود"
-    ]
-  },
-  {
-    "word": "Constructed type",
-    "is_checked": false,
-    "translations": [
-      "نوع مبني"
-    ]
-  },
-  {
-    "word": "Constructive",
-    "is_checked": false,
-    "translations": [
-      "بنائي"
-    ]
-  },
-  {
-    "word": "Constructive solid geometry",
-    "is_checked": false,
-    "translations": [
-      "هندسة صلبة بنائية"
-    ]
-  },
-  {
-    "word": "Constructor",
-    "is_checked": false,
-    "translations": [
-      "باني"
-    ]
-  },
-  {
-    "word": "Consultant",
-    "is_checked": false,
-    "translations": [
-      "مستشار"
-    ]
-  },
-  {
-    "word": "Contact",
-    "is_checked": false,
-    "translations": [
-      "مراسل"
-    ]
-  },
-  {
-    "word": "Contact (noun)",
-    "is_checked": false,
-    "translations": [
-      "معرفة"
-    ]
-  },
-  {
-    "word": "Contact (verb)",
-    "is_checked": false,
-    "translations": [
-      "اتصال"
-    ]
-  },
-  {
-    "word": "Container",
-    "is_checked": false,
-    "translations": [
-      "حاوية"
-    ]
-  },
-  {
-    "word": "Container class",
-    "is_checked": false,
-    "translations": [
-      "صنف واعٍ"
-    ]
-  },
-  {
-    "word": "Content",
-    "is_checked": false,
-    "translations": [
-      "محتوى"
-    ]
-  },
-  {
-    "word": "Content addressable memory",
-    "is_checked": false,
-    "translations": [
-      "ذاكرة ذات محتوى قابل للقصد"
-    ]
-  },
-  {
-    "word": "Content-based information retrieval",
-    "is_checked": false,
-    "translations": [
-      "سحب معلومات مبن على المحتوى"
-    ]
-  },
-  {
-    "word": "Contention slot",
-    "is_checked": false,
-    "translations": [
-      "مهلة تنازع"
-    ]
-  },
-  {
-    "word": "Context",
-    "is_checked": false,
-    "translations": [
-      "سياق"
-    ]
-  },
-  {
-    "word": "Context clash",
-    "is_checked": false,
-    "translations": [
-      "تعارض سياق"
-    ]
-  },
-  {
-    "word": "Context-free",
-    "is_checked": false,
-    "translations": [
-      "مستقل عن السياق"
-    ]
-  },
-  {
-    "word": "Context-free grammar",
-    "is_checked": false,
-    "translations": [
-      "نحو مستقل عن السياق"
-    ]
-  },
-  {
-    "word": "Context object",
-    "is_checked": false,
-    "translations": [
-      "كائن سياق"
-    ]
-  },
-  {
-    "word": "Context operator",
-    "is_checked": false,
-    "translations": [
-      "عامل سياق"
-    ]
-  },
-  {
-    "word": "Context-sensitive",
-    "is_checked": false,
-    "translations": [
-      "متأثر بالسياق"
-    ]
-  },
-  {
-    "word": "Context-sensitive menu",
-    "is_checked": false,
-    "translations": [
-      "قائمة خيارات متأثرة بالسياق"
-    ]
-  },
-  {
-    "word": "Context switch",
-    "is_checked": false,
-    "translations": [
-      "تبديل سياق"
-    ]
-  },
-  {
-    "word": "Contextual menu",
-    "is_checked": false,
-    "translations": [
-      "قائمة خيارات سياقية"
-    ]
-  },
-  {
-    "word": "Continuation",
-    "is_checked": false,
-    "translations": [
-      "استمرار",
-      "متابعة (برمجة دوال)",
-      "اتصال (دالة)"
-    ]
-  },
-  {
-    "word": "Continuation passing style",
-    "is_checked": false,
-    "translations": [
-      "أسلوب تمريرِ متابعة"
-    ]
-  },
-  {
-    "word": "Continue",
-    "is_checked": false,
-    "translations": [
-      "استمرار"
-    ]
-  },
-  {
-    "word": "Continuous",
-    "is_checked": false,
-    "translations": [
-      "مستمر",
-      "متصل (دالة",
-      "خط)",
-      "متواصل"
-    ]
-  },
-  {
-    "word": "Continuous function",
-    "is_checked": false,
-    "translations": [
-      "دالة متصلة"
-    ]
-  },
-  {
-    "word": "Continuous wave",
-    "is_checked": false,
-    "translations": [
-      "موجة متصلة"
-    ]
-  },
-  {
-    "word": "Contour",
-    "is_checked": false,
-    "translations": [
-      "محيط"
-    ]
-  },
-  {
-    "word": "Contraction",
-    "is_checked": false,
-    "translations": [
-      "تقليص"
-    ]
-  },
-  {
-    "word": "Contract programmer",
-    "is_checked": false,
-    "translations": [
-      "مبرمج تحت عقد"
-    ]
-  },
-  {
-    "word": "Contrast",
-    "is_checked": false,
-    "translations": [
-      "تباين"
-    ]
-  },
-  {
-    "word": "Contribution",
-    "is_checked": false,
-    "translations": [
-      "مساهمة"
-    ]
-  },
-  {
-    "word": "Contributor",
-    "is_checked": false,
-    "translations": [
-      "مساهِم"
-    ]
-  },
-  {
-    "word": "Control",
-    "is_checked": false,
-    "translations": [
-      "تحكّم"
-    ]
-  },
-  {
-    "word": "Control code",
-    "is_checked": false,
-    "translations": [
-      "رمز تحكم"
-    ]
-  },
-  {
-    "word": "Control file",
-    "is_checked": false,
-    "translations": [
-      "ملف تحكم"
-    ]
-  },
-  {
-    "word": "Control flow",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Controller",
-    "is_checked": false,
-    "translations": [
-      "متحكم"
-    ]
-  },
-  {
-    "word": "Control point",
-    "is_checked": false,
-    "translations": [
-      "نُقطة التحكم"
-    ]
-  },
-  {
-    "word": "Control structure",
-    "is_checked": false,
-    "translations": [
-      "بنية تحكم"
-    ]
-  },
-  {
-    "word": "Control unit",
-    "is_checked": false,
-    "translations": [
-      "وحدة تحكم"
-    ]
-  },
-  {
-    "word": "Conventional memory",
-    "is_checked": false,
-    "translations": [
-      "ذاكرة اصطلاحية"
-    ]
-  },
-  {
-    "word": "Converge",
-    "is_checked": false,
-    "translations": [
-      "يحتشد"
-    ]
-  },
-  {
-    "word": "Convergence",
-    "is_checked": false,
-    "translations": [
-      "إحتشاد"
-    ]
-  },
-  {
-    "word": "Conversation",
-    "is_checked": false,
-    "translations": [
-      "محادثة"
-    ]
-  },
-  {
-    "word": "Converse",
-    "is_checked": false,
-    "translations": [
-      "تحويل",
-      "عكس (منطق)"
-    ]
-  },
-  {
-    "word": "Conversion",
-    "is_checked": false,
-    "translations": [
-      "تحويل"
-    ]
-  },
-  {
-    "word": "Conversion to iteration",
-    "is_checked": false,
-    "translations": [
-      "تحويل إلى التكرار"
-    ]
-  },
-  {
-    "word": "Convert",
-    "is_checked": false,
-    "translations": [
-      "تحويل"
-    ]
-  },
-  {
-    "word": "Converting",
-    "is_checked": false,
-    "translations": [
-      "تحويل"
-    ]
-  },
-  {
-    "word": "Convex hull",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cooccurrence matrix",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cookie",
-    "is_checked": false,
-    "translations": [
-      "كعكة"
-    ]
-  },
-  {
-    "word": "Cooperative",
-    "is_checked": false,
-    "translations": [
-      "جماعي"
-    ]
-  },
-  {
-    "word": "Cooperative multitasking",
-    "is_checked": false,
-    "translations": [
-      "تعدد المهام التعاونيً"
-    ]
-  },
-  {
-    "word": "Coordinate",
-    "is_checked": false,
-    "translations": [
-      "تنسيق"
-    ]
-  },
-  {
-    "word": "Coordination language",
-    "is_checked": false,
-    "translations": [
-      "لغة تنسيق"
-    ]
-  },
-  {
-    "word": "Coprocessor",
-    "is_checked": false,
-    "translations": [
-      "معالج مساعد"
-    ]
-  },
-  {
-    "word": "Coproduct",
-    "is_checked": false,
-    "translations": [
-      "منتوج جانبي"
-    ]
-  },
-  {
-    "word": "Copy",
-    "is_checked": false,
-    "translations": [
-      "ينسخ"
-    ]
-  },
-  {
-    "word": "Copy and paste",
-    "is_checked": false,
-    "translations": [
-      "إنسخ وألصق"
-    ]
-  },
-  {
-    "word": "Copying garbage collection",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Copy left",
-    "is_checked": false,
-    "translations": [
-      "النسخ للجميع"
-    ]
-  },
-  {
-    "word": "Copyleft",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Copy (noun)",
-    "is_checked": false,
-    "translations": [
-      "نسخ"
-    ]
-  },
-  {
-    "word": "Copy protection",
-    "is_checked": false,
-    "translations": [
-      "حماية النسخ",
-      "حماية من النسخ"
-    ]
-  },
-  {
-    "word": "Copy right",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Copyright",
-    "is_checked": false,
-    "translations": [
-      "حقوق النشر",
-      "محفوظ الحقوق"
-    ]
-  },
-  {
-    "word": "Copyrighted",
-    "is_checked": false,
-    "translations": [
-      "محفوظ الحقوق"
-    ]
-  },
-  {
-    "word": "Copy (verb)",
-    "is_checked": false,
-    "translations": [
-      "نسخة"
-    ]
-  },
-  {
-    "word": "CORBA",
-    "is_checked": false,
-    "translations": [
-      "كوربا"
-    ]
-  },
-  {
-    "word": "Core",
-    "is_checked": false,
-    "translations": [
-      "لُب"
-    ]
-  },
-  {
-    "word": "Core class",
-    "is_checked": false,
-    "translations": [
-      "فئة باطنية"
-    ]
-  },
-  {
-    "word": "Core dump",
-    "is_checked": false,
-    "translations": [
-      "تفريغ الباطن"
-    ]
-  },
-  {
-    "word": "Core file",
-    "is_checked": false,
-    "translations": [
-      "ملف باطني"
-    ]
-  },
-  {
-    "word": "Core gateway",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Core leak",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Corner",
-    "is_checked": false,
-    "translations": [
-      "زاوِيَة"
-    ]
-  },
-  {
-    "word": "Corollary",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Corporate",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Corpus",
-    "is_checked": false,
-    "translations": [
-      "مكنز"
-    ]
-  },
-  {
-    "word": "Correct",
-    "is_checked": false,
-    "translations": [
-      "صحيح"
-    ]
-  },
-  {
-    "word": "Correlation",
-    "is_checked": false,
-    "translations": [
-      "تَعالُق"
-    ]
-  },
-  {
-    "word": "Correspondence",
-    "is_checked": false,
-    "translations": [
-      "تلاؤم"
-    ]
-  },
-  {
-    "word": "Correspondent",
-    "is_checked": false,
-    "translations": [
-      "موائم",
-      "متوائم"
-    ]
-  },
-  {
-    "word": "Corrupt",
-    "is_checked": false,
-    "translations": [
-      "فاسد"
-    ]
-  },
-  {
-    "word": "Cos",
-    "is_checked": false,
-    "translations": [
-      "جتا"
-    ]
-  },
-  {
-    "word": "Cost",
-    "is_checked": false,
-    "translations": [
-      "كلفة"
-    ]
-  },
-  {
-    "word": "Cost control callback",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Count",
-    "is_checked": false,
-    "translations": [
-      "تَعْداد"
-    ]
-  },
-  {
-    "word": "Countable",
-    "is_checked": false,
-    "translations": [
-      "قابل للتعداد"
-    ]
-  },
-  {
-    "word": "Counted",
-    "is_checked": false,
-    "translations": [
-      "معدود"
-    ]
-  },
-  {
-    "word": "Counting records",
-    "is_checked": false,
-    "translations": [
-      "تسجيلات العدً"
-    ]
-  },
-  {
-    "word": "Country code",
-    "is_checked": false,
-    "translations": [
-      "رمز البلد"
-    ]
-  },
-  {
-    "word": "Coupling",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Coupon",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Courseware",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Covariance",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "CPU",
-    "is_checked": false,
-    "translations": [
-      "معالج"
-    ]
-  },
-  {
-    "word": "Crack",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Crash",
-    "is_checked": false,
-    "translations": [
-      "انهيار"
-    ]
-  },
-  {
-    "word": "Crash dump",
-    "is_checked": false,
-    "translations": [
-      "تفريغ إنهياري"
-    ]
-  },
-  {
-    "word": "Crawler",
-    "is_checked": false,
-    "translations": [
-      "زاحف",
-      "داب"
-    ]
-  },
-  {
-    "word": "Create",
-    "is_checked": false,
-    "translations": [
-      "إنشاء"
-    ]
-  },
-  {
-    "word": "Creation",
-    "is_checked": false,
-    "translations": [
-      "إنشاء"
-    ]
-  },
-  {
-    "word": "Credential",
-    "is_checked": false,
-    "translations": [
-      "إعتماد"
-    ]
-  },
-  {
-    "word": "Credential cache",
-    "is_checked": false,
-    "translations": [
-      "خابية إعتمادية"
-    ]
-  },
-  {
-    "word": "Credits",
-    "is_checked": false,
-    "translations": [
-      "إشادات"
-    ]
-  },
-  {
-    "word": "Creeping featurism",
-    "is_checked": false,
-    "translations": [
-      "إسهال الميزات"
-    ]
-  },
-  {
-    "word": "Crisp",
-    "is_checked": false,
-    "translations": [
-      "مُتَقَصِّف"
-    ]
-  },
-  {
-    "word": "Critereon",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Criteria",
-    "is_checked": false,
-    "translations": [
-      "معيار"
-    ]
-  },
-  {
-    "word": "Criteria range",
-    "is_checked": false,
-    "translations": [
-      "مجال المواصفات"
-    ]
-  },
-  {
-    "word": "Criterion",
-    "is_checked": false,
-    "translations": [
-      "مِحك"
-    ]
-  },
-  {
-    "word": "Critical error",
-    "is_checked": false,
-    "translations": [
-      "خطأ حرج"
-    ]
-  },
-  {
-    "word": "Critical section",
-    "is_checked": false,
-    "translations": [
-      "جِزء حرِج"
-    ]
-  },
-  {
-    "word": "Cron",
-    "is_checked": false,
-    "translations": [
-      "الدورية"
-    ]
-  },
-  {
-    "word": "Crop",
-    "is_checked": false,
-    "translations": [
-      "اقتصاص"
-    ]
-  },
-  {
-    "word": "Cross-assembler",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cross compilation",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cross-compiler",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cross-device link",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Crossed",
-    "is_checked": false,
-    "translations": [
-      "تصالب",
-      "تقاطع"
-    ]
-  },
-  {
-    "word": "Cross-fade",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Crossfade",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cross-fading",
-    "is_checked": false,
-    "translations": [
-      "خفوت"
-    ]
-  },
-  {
-    "word": "Crosshair",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cross-over",
-    "is_checked": false,
-    "translations": [
-      "معبر"
-    ]
-  },
-  {
-    "word": "Cross-platform",
-    "is_checked": false,
-    "translations": [
-      "متعدد المنصات"
-    ]
-  },
-  {
-    "word": "Cross-reference",
-    "is_checked": false,
-    "translations": [
-      "إحالة"
-    ]
-  },
-  {
-    "word": "Cruft",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cruft together",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Crumb",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Crypt",
-    "is_checked": false,
-    "translations": [
-      "تشفير"
-    ]
-  },
-  {
-    "word": "Cryptanalysis",
-    "is_checked": false,
-    "translations": [
-      "تحليل التعمية"
-    ]
-  },
-  {
-    "word": "Cryptography",
-    "is_checked": false,
-    "translations": [
-      "علم التعمية"
-    ]
-  },
-  {
-    "word": "Cryptology",
-    "is_checked": false,
-    "translations": [
-      "علم التشفير"
-    ]
-  },
-  {
-    "word": "CSS",
-    "is_checked": false,
-    "translations": [
-      "CSS"
-    ]
-  },
-  {
-    "word": "Ctrl",
-    "is_checked": false,
-    "translations": [
-      "Ctrl"
-    ]
-  },
-  {
-    "word": "Cube",
-    "is_checked": false,
-    "translations": [
-      "مكعّب"
-    ]
-  },
-  {
-    "word": "Cubing",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cumulative",
-    "is_checked": false,
-    "translations": [
-      "تراكمي"
-    ]
-  },
-  {
-    "word": "CUPS",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Curly bracket",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Current",
-    "is_checked": false,
-    "translations": [
-      "حالي"
-    ]
-  },
-  {
-    "word": "Current directory",
-    "is_checked": false,
-    "translations": [
-      "الدليل الحالي"
-    ]
-  },
-  {
-    "word": "Current session",
-    "is_checked": false,
-    "translations": [
-      "الجلسة الحالية"
-    ]
-  },
-  {
-    "word": "Current working",
-    "is_checked": false,
-    "translations": [
-      "الأعمال الجارية",
-      "الأشغال الجارية"
-    ]
-  },
-  {
-    "word": "Curried function",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Currying",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cursor",
-    "is_checked": false,
-    "translations": [
-      "مُؤشر (الفأرة)"
-    ]
-  },
-  {
-    "word": "Cursor keys",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cursor plane",
-    "is_checked": false,
-    "translations": [
-      "سطح المنزلق"
-    ]
-  },
-  {
-    "word": "Curve",
-    "is_checked": false,
-    "translations": [
-      "منحنية"
-    ]
-  },
-  {
-    "word": "Custom",
-    "is_checked": false,
-    "translations": [
-      "مخصص"
-    ]
-  },
-  {
-    "word": "Customization",
-    "is_checked": false,
-    "translations": [
-      "تخصيص"
-    ]
-  },
-  {
-    "word": "Customize",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Custom window",
-    "is_checked": false,
-    "translations": [
-      "النافذة الإصطلاحية"
-    ]
-  },
-  {
-    "word": "Cut",
-    "is_checked": false,
-    "translations": [
-      "قص"
-    ]
-  },
-  {
-    "word": "Cut and paste",
-    "is_checked": false,
-    "translations": [
-      "قص والصق"
-    ]
-  },
-  {
-    "word": "Cut buffer",
-    "is_checked": false,
-    "translations": [
-      "صِوان القصً"
-    ]
-  },
-  {
-    "word": "Cutover",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cut-through switching",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cyber",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cyberbunny",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cybercafe",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cybernetics",
-    "is_checked": false,
-    "translations": [
-      "التحكم الآلي"
-    ]
-  },
-  {
-    "word": "Cyberspace",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cyber-squatting",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cyborg",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cycle",
-    "is_checked": false,
-    "translations": [
-      "دورة"
-    ]
-  },
-  {
-    "word": "Cyclebabble",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cycle crunch",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cycle drought",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cycle of reincarnation",
-    "is_checked": false,
-    "translations": [
-      "دورة التناسخ"
-    ]
-  },
-  {
-    "word": "Cycle server",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cyclic redundancy check",
-    "is_checked": false,
-    "translations": [
-      "تدقيق دوري عن الأخطاء"
-    ]
-  },
-  {
-    "word": "Cyclic redundancy code",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cyclomatic complexity",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Cylinder",
-    "is_checked": false,
-    "translations": [
-      "اسطوانة"
-    ]
-  },
-  {
-    "word": "Daemon",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Daisy chain",
-    "is_checked": false,
-    "translations": [
-      "سلسلة تعاقبيّة"
-    ]
-  },
-  {
-    "word": "Daisywheel printer",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Damage",
-    "is_checked": false,
-    "translations": [
-      "ضرر"
-    ]
-  },
-  {
-    "word": "Dangling pointer",
-    "is_checked": false,
-    "translations": [
-      "مؤشر مدلًى"
-    ]
-  },
-  {
-    "word": "Dash",
-    "is_checked": false,
-    "translations": [
-      "شَرطة"
-    ]
-  },
-  {
-    "word": "Dashboard",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Data",
-    "is_checked": false,
-    "translations": [
-      "بيانات"
-    ]
-  },
-  {
-    "word": "Data abstraction",
-    "is_checked": false,
-    "translations": [
-      "تَجريد البيانات"
-    ]
-  },
-  {
-    "word": "Data acquisition",
-    "is_checked": false,
-    "translations": [
-      "تحصيل (استحصال) معطيات"
-    ]
-  },
-  {
-    "word": "Database",
-    "is_checked": false,
-    "translations": [
-      "قاعدة بيانات"
-    ]
-  },
-  {
-    "word": "Database administrator",
-    "is_checked": false,
-    "translations": [
-      "مدير قاعدة معطيات"
-    ]
-  },
-  {
-    "word": "Database analyst",
-    "is_checked": false,
-    "translations": [
-      "محلل قاعدة معطيات"
-    ]
-  },
-  {
-    "word": "Database machine",
-    "is_checked": false,
-    "translations": [
-      "مكنة قاعدة معطيات"
-    ]
-  },
-  {
-    "word": "Database management system",
-    "is_checked": false,
-    "translations": [
-      "نظام تدبير قاعدة المعطيات"
-    ]
-  },
-  {
-    "word": "Database manager",
-    "is_checked": false,
-    "translations": [
-      "مدير قاعدة بيانات"
-    ]
-  },
-  {
-    "word": "Database normalisation",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Database query language",
-    "is_checked": false,
-    "translations": [
-      "لغة استعلام قواعد البيانات"
-    ]
-  },
-  {
-    "word": "Database server",
-    "is_checked": false,
-    "translations": [
-      "خادم قاعدة معطيات"
-    ]
-  },
-  {
-    "word": "Data bus",
-    "is_checked": false,
-    "translations": [
-      "ناقل البيانات"
-    ]
-  },
-  {
-    "word": "Datacenter manager",
-    "is_checked": false,
-    "translations": [
-      "مدير مركز البيانات"
-    ]
-  },
-  {
-    "word": "Data channel",
-    "is_checked": false,
-    "translations": [
-      "قناة البيانات"
-    ]
-  },
-  {
-    "word": "Data communications analyst",
-    "is_checked": false,
-    "translations": [
-      "محلل مواصلات المعطيات"
-    ]
-  },
-  {
-    "word": "Data compression",
-    "is_checked": false,
-    "translations": [
-      "ضغط بيانات"
-    ]
-  },
-  {
-    "word": "Data connection",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Data dictionary",
-    "is_checked": false,
-    "translations": [
-      "قاموس بيانات"
-    ]
-  },
-  {
-    "word": "Data dictionary file",
-    "is_checked": false,
-    "translations": [
-      "ملف قاموس بيانات"
-    ]
-  },
-  {
-    "word": "Data driven",
-    "is_checked": false,
-    "translations": [
-      "مُساق من البيانات"
-    ]
-  },
-  {
-    "word": "Data flow",
-    "is_checked": false,
-    "translations": [
-      "تدفّق البيانات"
-    ]
-  },
-  {
-    "word": "Dataflow",
-    "is_checked": false,
-    "translations": [
-      "تدفًق بيانات"
-    ]
-  },
-  {
-    "word": "Data flow analysis",
-    "is_checked": false,
-    "translations": [
-      "تحليل تدفًق بيانات"
-    ]
-  },
-  {
-    "word": "Data flow diagram",
-    "is_checked": false,
-    "translations": [
-      "مخطًط تدفق البيانات"
-    ]
-  },
-  {
-    "word": "Data fork",
-    "is_checked": false,
-    "translations": [
-      "تشعًب معطيات"
-    ]
-  },
-  {
-    "word": "Data frame",
-    "is_checked": false,
-    "translations": [
-      "إطار قاعدة معطيات"
-    ]
-  },
-  {
-    "word": "Data glove",
-    "is_checked": false,
-    "translations": [
-      "قفاز بيانات"
-    ]
-  },
-  {
-    "word": "Datagramt",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Data hierarchy",
-    "is_checked": false,
-    "translations": [
-      "هرميَّة البيانات"
-    ]
-  },
-  {
-    "word": "Dataless client",
-    "is_checked": false,
-    "translations": [
-      "زبون خالي من المعطيات"
-    ]
-  },
-  {
-    "word": "Dataless management utility",
-    "is_checked": false,
-    "translations": [
-      "منفعة تدبير خالية من المعطيات"
-    ]
-  },
-  {
-    "word": "Data link layer",
-    "is_checked": false,
-    "translations": [
-      "طبقة وصل المعطيات"
-    ]
-  },
-  {
-    "word": "Data link level",
-    "is_checked": false,
-    "translations": [
-      "مستوى وصل المعطيات"
-    ]
-  },
-  {
-    "word": "Data logger",
-    "is_checked": false,
-    "translations": [
-      "مسجّل بيانات"
-    ]
-  },
-  {
-    "word": "Data logging",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Data mart",
-    "is_checked": false,
-    "translations": [
-      "سوق قاعدة معطيات"
-    ]
-  },
-  {
-    "word": "Data mining",
-    "is_checked": false,
-    "translations": [
-      "أستغلال البيانات"
-    ]
-  },
-  {
-    "word": "Data model",
-    "is_checked": false,
-    "translations": [
-      "نموذج المعطيات"
-    ]
-  },
-  {
-    "word": "Data modeling",
-    "is_checked": false,
-    "translations": [
-      "نمذجة المعطيات"
-    ]
-  },
-  {
-    "word": "Data modelling",
-    "is_checked": false,
-    "translations": [
-      "نمذجة المعطيات"
-    ]
-  },
-  {
-    "word": "Data packet",
-    "is_checked": false,
-    "translations": [
-      "رزمة بيانات"
-    ]
-  },
-  {
-    "word": "Data path",
-    "is_checked": false,
-    "translations": [
-      "مسار بيانات"
-    ]
-  },
-  {
-    "word": "Data processing",
-    "is_checked": false,
-    "translations": [
-      "معالجة البيانات"
-    ]
-  },
-  {
-    "word": "Data rate",
-    "is_checked": false,
-    "translations": [
-      "معدل نقل البيانات"
-    ]
-  },
-  {
-    "word": "Data segment",
-    "is_checked": false,
-    "translations": [
-      "قطعة بيانات"
-    ]
-  },
-  {
-    "word": "Data service",
-    "is_checked": false,
-    "translations": [
-      "خدمة بيانات"
-    ]
-  },
-  {
-    "word": "Data service unit",
-    "is_checked": false,
-    "translations": [
-      "وحدة خدمة البيانات"
-    ]
-  },
-  {
-    "word": "Data set",
-    "is_checked": false,
-    "translations": [
-      "مجموعة بيانات"
-    ]
-  },
-  {
-    "word": "Dataset",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Data set organization",
-    "is_checked": false,
-    "translations": [
-      "تنظيم مجموعة البيانات"
-    ]
-  },
-  {
-    "word": "Data striping",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Data structure",
-    "is_checked": false,
-    "translations": [
-      "بنية البيانات"
-    ]
-  },
-  {
-    "word": "Data transfer bus",
-    "is_checked": false,
-    "translations": [
-      "مسرى نقل المعطيات"
-    ]
-  },
-  {
-    "word": "Data transfer rate",
-    "is_checked": false,
-    "translations": [
-      "معدّل نقل البيانات"
-    ]
-  },
-  {
-    "word": "Data type",
-    "is_checked": false,
-    "translations": [
-      "نوع البيانات"
-    ]
-  },
-  {
-    "word": "Datatype definition",
-    "is_checked": false,
-    "translations": [
-      "تعريف نوع المعطيات"
-    ]
-  },
-  {
-    "word": "Data unit",
-    "is_checked": false,
-    "translations": [
-      "وحدة بيانات"
-    ]
-  },
-  {
-    "word": "Data warehouse",
-    "is_checked": false,
-    "translations": [
-      "مخزن معطيات"
-    ]
-  },
-  {
-    "word": "Data warehousing",
-    "is_checked": false,
-    "translations": [
-      "خزن المعطيات"
-    ]
-  },
-  {
-    "word": "Date",
-    "is_checked": false,
-    "translations": [
-      "تاريخ"
-    ]
-  },
-  {
-    "word": "Datum",
-    "is_checked": false,
-    "translations": [
-      "معطى"
-    ]
-  },
-  {
-    "word": "Daughter",
-    "is_checked": false,
-    "translations": [
-      "سليلة"
-    ]
-  },
-  {
-    "word": "Daughterboard",
-    "is_checked": false,
-    "translations": [
-      "لوحة سليلة"
-    ]
-  },
-  {
-    "word": "Daughtercard",
-    "is_checked": false,
-    "translations": [
-      "بطاقة سليلة"
-    ]
-  },
-  {
-    "word": "Day",
-    "is_checked": false,
-    "translations": [
-      "يوم"
-    ]
-  },
-  {
-    "word": "Day mode",
-    "is_checked": false,
-    "translations": [
-      "نهاري النمط"
-    ]
-  },
-  {
-    "word": "Deactivate",
-    "is_checked": false,
-    "translations": [
-      "بطّل"
-    ]
-  },
-  {
-    "word": "Dead",
-    "is_checked": false,
-    "translations": [
-      "عاطل",
-      "ميت"
-    ]
-  },
-  {
-    "word": "Dead code",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Deadlock",
-    "is_checked": false,
-    "translations": [
-      "أزمة",
-      "مأزق"
-    ]
-  },
-  {
-    "word": "Deadly embrace",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Dealer",
-    "is_checked": false,
-    "translations": [
-      "مُتَّجِر"
-    ]
-  },
-  {
-    "word": "Death code",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Deb",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Debianize",
-    "is_checked": false,
-    "translations": [
-      "دَبيَنة"
-    ]
-  },
-  {
-    "word": "Debug",
-    "is_checked": false,
-    "translations": [
-      "تنقيح"
-    ]
-  },
-  {
-    "word": "Debugger",
-    "is_checked": false,
-    "translations": [
-      "منقّح"
-    ]
-  },
-  {
-    "word": "Debugging",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Decay",
-    "is_checked": false,
-    "translations": [
-      "تضاؤل"
-    ]
-  },
-  {
-    "word": "Dechunker",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Decidability",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Decidable",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Decimal",
-    "is_checked": false,
-    "translations": [
-      "عشري"
-    ]
-  },
-  {
-    "word": "Decimal point",
-    "is_checked": false,
-    "translations": [
-      "فاصل عُشري"
-    ]
-  },
-  {
-    "word": "Decision problem",
-    "is_checked": false,
-    "translations": [
-      "مشكلة قرار"
-    ]
-  },
-  {
-    "word": "Decision support",
-    "is_checked": false,
-    "translations": [
-      "دعم قرار"
-    ]
-  },
-  {
-    "word": "Decision support database",
-    "is_checked": false,
-    "translations": [
-      "قاعدة بيانات دعم القرار",
-      "قاعدة معلومات دعم القرار"
-    ]
-  },
-  {
-    "word": "Decision theory",
-    "is_checked": false,
-    "translations": [
-      "نظرية القرار"
-    ]
-  },
-  {
-    "word": "Declaration",
-    "is_checked": false,
-    "translations": [
-      "إبلاغ",
-      "علانية"
-    ]
-  },
-  {
-    "word": "Declarative language",
-    "is_checked": false,
-    "translations": [
-      "لغة تقريرية"
-    ]
-  },
-  {
-    "word": "Declare",
-    "is_checked": false,
-    "translations": [
-      "إدلاء",
-      "إعلان"
-    ]
-  },
-  {
-    "word": "Decode",
-    "is_checked": false,
-    "translations": [
-      "فك ترميز"
-    ]
-  },
-  {
-    "word": "Decoder",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Decompress",
-    "is_checked": false,
-    "translations": [
-      "فك ضغط"
-    ]
-  },
-  {
-    "word": "Decorative",
-    "is_checked": false,
-    "translations": [
-      "زخرفي"
-    ]
-  },
-  {
-    "word": "Decrease",
-    "is_checked": false,
-    "translations": [
-      "تخفيض",
-      "تخفيف",
-      "تقليل"
-    ]
-  },
-  {
-    "word": "Decrypt",
-    "is_checked": false,
-    "translations": [
-      "فَك التعمية"
-    ]
-  },
-  {
-    "word": "Decryption",
-    "is_checked": false,
-    "translations": [
-      "فك تشفير"
-    ]
-  },
-  {
-    "word": "Dedicated line",
-    "is_checked": false,
-    "translations": [
-      "خطً مُكرًس"
-    ]
-  },
-  {
-    "word": "Deductive database",
-    "is_checked": false,
-    "translations": [
-      "قاعدة معطيات إستنتاجية"
-    ]
-  },
-  {
-    "word": "Deductive tableau",
-    "is_checked": false,
-    "translations": [
-      "لوح إستنتاجي"
-    ]
-  },
-  {
-    "word": "Deep",
-    "is_checked": false,
-    "translations": [
-      "غميق"
-    ]
-  },
-  {
-    "word": "Deep magic",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "De facto standard",
-    "is_checked": false,
-    "translations": [
-      "معيار فعلي",
-      "معيار واقعي"
-    ]
-  },
-  {
-    "word": "Default",
-    "is_checked": false,
-    "translations": [
-      "مبدئي"
-    ]
-  },
-  {
-    "word": "Default master",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Default route",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Defect",
-    "is_checked": false,
-    "translations": [
-      "عيب"
-    ]
-  },
-  {
-    "word": "Defect analysis",
-    "is_checked": false,
-    "translations": [
-      "تحليل العلًة"
-    ]
-  },
-  {
-    "word": "Defect density",
-    "is_checked": false,
-    "translations": [
-      "كثافة العلل"
-    ]
-  },
-  {
-    "word": "Deferral",
-    "is_checked": false,
-    "translations": [
-      "إِرْجاء"
-    ]
-  },
-  {
-    "word": "Define",
-    "is_checked": false,
-    "translations": [
-      "تعريف",
-      "تحديد"
-    ]
-  },
-  {
-    "word": "Definite clause",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Definite sentence",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Definition",
-    "is_checked": false,
-    "translations": [
-      "تعريف"
-    ]
-  },
-  {
-    "word": "Definitional constraint programming",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Deflate",
-    "is_checked": false,
-    "translations": [
-      "منكمش"
-    ]
-  },
-  {
-    "word": "Deflate compression",
-    "is_checked": false,
-    "translations": [
-      "ضغط منكمش"
-    ]
-  },
-  {
-    "word": "Deforestation",
-    "is_checked": false,
-    "translations": [
-      "إجتثاث الغابة",
-      "إزالة الغابة"
-    ]
-  },
-  {
-    "word": "Defragment",
-    "is_checked": false,
-    "translations": [
-      "إزالة التشظية"
-    ]
-  },
-  {
-    "word": "Defunct process",
-    "is_checked": false,
-    "translations": [
-      "إجراء ميت",
-      "إجراء فان"
-    ]
-  },
-  {
-    "word": "Degree",
-    "is_checked": false,
-    "translations": [
-      "درجة"
-    ]
-  },
-  {
-    "word": "Degrees",
-    "is_checked": false,
-    "translations": [
-      "درجات"
-    ]
-  },
-  {
-    "word": "Degrees of freedom",
-    "is_checked": false,
-    "translations": [
-      "درجات الحرية"
-    ]
-  },
-  {
-    "word": "Deinstallation",
-    "is_checked": false,
-    "translations": [
-      "إزالة التثبيت",
-      "فك التثبيت"
-    ]
-  },
-  {
-    "word": "Deinterlace",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Dejagging",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Delay",
-    "is_checked": false,
-    "translations": [
-      "مهلة",
-      "تأخير"
-    ]
-  },
-  {
-    "word": "Delayed control-transfer",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Delay instruction",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Delay slot",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Delegation",
-    "is_checked": false,
-    "translations": [
-      "بعثة",
-      "نيابة"
-    ]
-  },
-  {
-    "word": "Delete",
-    "is_checked": false,
-    "translations": [
-      "حذف"
-    ]
-  },
-  {
-    "word": "Deletia",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Deletion",
-    "is_checked": false,
-    "translations": [
-      "حذف"
-    ]
-  },
-  {
-    "word": "Delimiter",
-    "is_checked": false,
-    "translations": [
-      "مُحِد"
-    ]
-  },
-  {
-    "word": "Deliverable",
-    "is_checked": false,
-    "translations": [
-      "مُسْتَلَم"
-    ]
-  },
-  {
-    "word": "Delivery",
-    "is_checked": false,
-    "translations": [
-      "تسليم"
-    ]
-  },
-  {
-    "word": "Delta",
-    "is_checked": false,
-    "translations": [
-      "دَال"
-    ]
-  },
-  {
-    "word": "Delta conversion",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Delta reduction",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Demand",
-    "is_checked": false,
-    "translations": [
-      "ألضرورة",
-      "المطلب"
-    ]
-  },
-  {
-    "word": "Demand driven",
-    "is_checked": false,
-    "translations": [
-      "منساق بلضرورة"
-    ]
-  },
-  {
-    "word": "Demand paged",
-    "is_checked": false,
-    "translations": [
-      "صفحيً الضرورة"
-    ]
-  },
-  {
-    "word": "Demand paging",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Demo",
-    "is_checked": false,
-    "translations": [
-      "عرض"
-    ]
-  },
-  {
-    "word": "Demodulate",
-    "is_checked": false,
-    "translations": [
-      "فكً الترنيم",
-      "كشف الترنيم"
-    ]
-  },
-  {
-    "word": "Demodulation",
-    "is_checked": false,
-    "translations": [
-      "كشف الترنيم"
-    ]
-  },
-  {
-    "word": "Demo mode",
-    "is_checked": false,
-    "translations": [
-      "نمط العرض التوضيحي"
-    ]
-  },
-  {
-    "word": "Demote",
-    "is_checked": false,
-    "translations": [
-      "حط من الرتبة"
-    ]
-  },
-  {
-    "word": "Demo version",
-    "is_checked": false,
-    "translations": [
-      "اصدارة العرض التوضيحي"
-    ]
-  },
-  {
-    "word": "Denominator",
-    "is_checked": false,
-    "translations": [
-      "قاسم"
-    ]
-  },
-  {
-    "word": "Denotational semantics",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Deny",
-    "is_checked": false,
-    "translations": [
-      "رفض"
-    ]
-  },
-  {
-    "word": "Depeditate",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Dependability",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Dependable software",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Dependancy",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Dependence",
-    "is_checked": false,
-    "translations": [
-      "تبعية",
-      "ارتباط"
-    ]
-  },
-  {
-    "word": "Dependency",
-    "is_checked": false,
-    "translations": [
-      "اعتمادية"
-    ]
-  },
-  {
-    "word": "Deprecate",
-    "is_checked": false,
-    "translations": [
-      "أدان"
-    ]
-  },
-  {
-    "word": "Deprecated",
-    "is_checked": false,
-    "translations": [
-      "مهجور"
-    ]
-  },
-  {
-    "word": "Deprecation",
-    "is_checked": false,
-    "translations": [
-      "إِدَانَة"
-    ]
-  },
-  {
-    "word": "Depth",
-    "is_checked": false,
-    "translations": [
-      "عمق"
-    ]
-  },
-  {
-    "word": "Depth-first search",
-    "is_checked": false,
-    "translations": [
-      "البحث بالعمق أولا"
-    ]
-  },
-  {
-    "word": "Dereference",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Derivative",
-    "is_checked": false,
-    "translations": [
-      "مشتق"
-    ]
-  },
-  {
-    "word": "Derived",
-    "is_checked": false,
-    "translations": [
-      "مُشتق"
-    ]
-  },
-  {
-    "word": "Derived class",
-    "is_checked": false,
-    "translations": [
-      "فئة مشتقة"
-    ]
-  },
-  {
-    "word": "Derived type",
-    "is_checked": false,
-    "translations": [
-      "نوع مشتق"
-    ]
-  },
-  {
-    "word": "Desaturate",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Descender",
-    "is_checked": false,
-    "translations": [
-      "مخسوف",
-      "هابط"
-    ]
-  },
-  {
-    "word": "Descending",
-    "is_checked": false,
-    "translations": [
-      "تناقصي"
-    ]
-  },
-  {
-    "word": "Descending sort",
-    "is_checked": false,
-    "translations": [
-      "ترتيب تنازلي"
-    ]
-  },
-  {
-    "word": "Descent function",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Description",
-    "is_checked": false,
-    "translations": [
-      "الوصف"
-    ]
-  },
-  {
-    "word": "Descriptor",
-    "is_checked": false,
-    "translations": [
-      "واصف"
-    ]
-  },
-  {
-    "word": "Deselect",
-    "is_checked": false,
-    "translations": [
-      "عدم انتقاء"
-    ]
-  },
-  {
-    "word": "Design",
-    "is_checked": false,
-    "translations": [
-      "تصميم"
-    ]
-  },
-  {
-    "word": "Design pattern",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Design recovery",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Desk",
-    "is_checked": false,
-    "translations": [
-      "مِنضدة",
-      "مكتب"
-    ]
-  },
-  {
-    "word": "Desk check",
-    "is_checked": false,
-    "translations": [
-      "فحص مكتبي"
-    ]
-  },
-  {
-    "word": "Deskside",
-    "is_checked": false,
-    "translations": [
-      "جانب المنضدة",
-      "جانب المكتب"
-    ]
-  },
-  {
-    "word": "Desktop",
-    "is_checked": false,
-    "translations": [
-      "سطح مكتب"
-    ]
-  },
-  {
-    "word": "Desktop background",
-    "is_checked": false,
-    "translations": [
-      "خلفية سطح المكتب"
-    ]
-  },
-  {
-    "word": "Desktop database",
-    "is_checked": false,
-    "translations": [
-      "قاعدة بيانات سطح المكتب"
-    ]
-  },
-  {
-    "word": "Desktop environment",
-    "is_checked": false,
-    "translations": [
-      "محيط سطح المكتب"
-    ]
-  },
-  {
-    "word": "Desktop manager",
-    "is_checked": false,
-    "translations": []
-  },
-  {
-    "word": "Desktop publisher",
-    "is_checked": false,
-    "translations": [
-      "محرر سطح المكتب"
-    ]
-  },
-  {
-    "word": "Desktop publishing",
-    "is_checked": false,
-    "translations": [
-      "نشر عبر سطح المكتب"
-    ]
-  },
-  {
-    "word": "Destination",
-    "is_checked": false,
-    "translations": [
-      "مقصد"
-    ]
-  }
+    {
+        "word": "Abort",
+        "translations": [
+            "إجهاض"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Abortive release",
+        "translations": [
+            "انقطاع (شبكي) مجهض"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Abscissa",
+        "translations": [
+            "فاصلة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Absolute",
+        "translations": [
+            "مطلق(ة) (قيمة)"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Absolute address",
+        "translations": [
+            "عنوان مطلق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Absolute path",
+        "translations": [
+            "مسار مطلق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Absolute pathname",
+        "translations": [
+            "اسم مسار مطلق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Abstract",
+        "translations": [
+            "مجرَّد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Abstract class",
+        "translations": [
+            "صنف مجرد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Abstract data type",
+        "translations": [
+            "نوع بيانات مجرد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Abstract datatype",
+        "translations": [
+            "نوع بيانات مجرد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Abstract interpretation",
+        "translations": [
+            "تأويل مجرد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Abstraction",
+        "translations": [
+            "تجريد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Abstract machine",
+        "translations": [
+            "آلة مجردة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Abstract method",
+        "translations": [
+            "طريقة مجردة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Abstract syntax",
+        "translations": [
+            "بنية مجردة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Abstract syntax tree",
+        "translations": [
+            "شجرة بنية مجردة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Accelerated Graphics",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Accelerator",
+        "translations": [
+            "مسرِّع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Accent",
+        "translations": [
+            "حركة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Accept",
+        "translations": [
+            "قبول"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Acceptance testing",
+        "translations": [
+            "اختبار القبول"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Access",
+        "translations": [
+            "نفاذ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Access control list",
+        "translations": [
+            "قائمة التحكم بالنفاذ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Accessibility",
+        "translations": [
+            "إتاحة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Accessible",
+        "translations": [
+            "مُتَاح"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Access level",
+        "translations": [
+            "مستوى النفاذ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Access memory",
+        "translations": [
+            "ذاكرة النفاذ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Accessory",
+        "translations": [
+            "كمالي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Access point",
+        "translations": [
+            "نقطة العبور"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Account",
+        "translations": [
+            "حساب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Accounting management",
+        "translations": [
+            "تسيير الحسابات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Accumulator",
+        "translations": [
+            "مركِّم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Accuracy",
+        "translations": [
+            "دقة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Acknowledgment",
+        "translations": [
+            "عرفان :: شكر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Acoustic coupler",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Acquire",
+        "translations": [
+            "اكتساب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Acronym",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Action",
+        "translations": [
+            "إجراء"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Activate",
+        "translations": [
+            "تنشيط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Active",
+        "translations": [
+            "نشِيط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Activity",
+        "translations": [
+            "نشاط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Actor",
+        "translations": [
+            "فاعل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Actuator",
+        "translations": [
+            "مشغّل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Adapt",
+        "translations": [
+            "تكييف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Adapter",
+        "translations": [
+            "مكيف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Adaptive answering",
+        "translations": [
+            "إجابة تكيفية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Adaptive learning",
+        "translations": [
+            "تعلم تكييفي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Adaptive routing",
+        "translations": [
+            "توجيه تكيفي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Add",
+        "translations": [
+            "إضافة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Add-in",
+        "translations": [
+            "مضاف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Add-In",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Additional",
+        "translations": [
+            "إضافي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Additive",
+        "translations": [
+            "انضمامي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Addon",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Addon CD",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Address",
+        "translations": [
+            "عنوان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Address book",
+        "translations": [
+            "دفتر عناوين"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Address bus",
+        "translations": [
+            "ناقل عناوين"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Addressee",
+        "translations": [
+            "مرسل إليه"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Addressing",
+        "translations": [
+            "عنونة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Adjacency",
+        "translations": [
+            "تجاور"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Adjacent",
+        "translations": [
+            "مجاور"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Adjust",
+        "translations": [
+            "ضبط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Admin",
+        "translations": [
+            "مدير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Administration",
+        "translations": [
+            "إدارة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Administrative",
+        "translations": [
+            "إداري"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Administrator",
+        "translations": [
+            "مدير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Advance",
+        "translations": [
+            "تقدم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Advanced",
+        "translations": [
+            "متقدم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Affix",
+        "translations": [
+            "زائدة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Agenda",
+        "translations": [
+            "مفكرة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Agent",
+        "translations": [
+            "مفوّض"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Aggregate",
+        "translations": [
+            "مُجمَل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Aggregate type",
+        "translations": [
+            "نوع مُجمَل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Aggregation",
+        "translations": [
+            "تجميع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Aggregator",
+        "translations": [
+            "مُجمِّع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Aging",
+        "translations": [
+            "تقادم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "AGP",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Agree",
+        "translations": [
+            "موافق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Agreement",
+        "translations": [
+            "اتفاق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Airbrush",
+        "translations": [
+            "مرذاذ صباغة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Alarm",
+        "translations": [
+            "منبه"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Alarm clock",
+        "translations": [
+            "منبه"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Aleph",
+        "translations": [
+            "ألف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Alert",
+        "translations": [
+            "تنبيه"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Alert box",
+        "translations": [
+            "حوار التنبيه"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Algebraic data type",
+        "translations": [
+            "نوع بيانات جبري"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Algebraic structure",
+        "translations": [
+            "بنية جبرية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Algorism",
+        "translations": [
+            "خوارزميّة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Algorithm",
+        "translations": [
+            "خوارزمية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Alias",
+        "translations": [
+            "كنية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Aliasing",
+        "translations": [
+            "تسنن"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Aliasing bug",
+        "translations": [
+            "خلل تسنّن"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Align",
+        "translations": [
+            "محاذاة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Alignment",
+        "translations": [
+            "محاذاة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Allocate",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Allow",
+        "translations": [
+            "سماح"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Alpha",
+        "translations": [
+            "ألفا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Alpha channel",
+        "translations": [
+            "قناة ألفا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Alphanumeric",
+        "translations": [
+            "أبجدي عددي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "ALSA",
+        "translations": [
+            "بنية لينكس الصوتية المتقدمة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Alter",
+        "translations": [
+            "تغيير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Alteration",
+        "translations": [
+            "تغيير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Alternating",
+        "translations": [
+            "تناوبي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Alternative",
+        "translations": [
+            "بديل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Amount",
+        "translations": [
+            "كمية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Amper",
+        "translations": [
+            "أمبير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Amplify",
+        "translations": [
+            "تضخيم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Amplitude",
+        "translations": [
+            "سعة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Analog",
+        "translations": [
+            "نظير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Analogue computer",
+        "translations": [
+            "حاسوب تماثلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Analysis",
+        "translations": [
+            "تحليل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Anchor",
+        "translations": [
+            "مربط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Anchoring",
+        "translations": [
+            "إرساء"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "AND",
+        "translations": [
+            "و"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Angle",
+        "translations": [
+            "زاوية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Angle bracket",
+        "translations": [
+            "مكسورة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Animate",
+        "translations": [
+            "تحريك"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Animation",
+        "translations": [
+            "حركة/رسوم متحركة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Anisotropy",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Annotate",
+        "translations": [
+            "تعليق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Annotation",
+        "translations": [
+            "تعليق :: حاشية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Announce",
+        "translations": [
+            "إعلان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Announcement",
+        "translations": [
+            "إعلان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Anonymous",
+        "translations": [
+            "مجهول الاسم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Answer mode",
+        "translations": [
+            "نمط الإجابة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Antialias",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Anti-aliasing",
+        "translations": [
+            "إزالة التسنن"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Antialiasing",
+        "translations": [
+            "إزالة التسنن"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Antisymmetric",
+        "translations": [
+            "لا متماثل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Anti virus",
+        "translations": [
+            "مضاد فيروسات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Antivirus",
+        "translations": [
+            "مضاد فيروسات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Antivirus software",
+        "translations": [
+            "برنامج مضاد للفيروسات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Anytime algorithm",
+        "translations": [
+            "خوارزمية لا وقتية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "API",
+        "translations": [
+            "واجهة برمجة التطبيقات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Apostrophe",
+        "translations": [
+            "فاصلة عليا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Appear",
+        "translations": [
+            "ظهور"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Append",
+        "translations": [
+            "إلحاق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Applet",
+        "translations": [
+            "بريمج"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Application",
+        "translations": [
+            "تطبيق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Application Launcher",
+        "translations": [
+            "مشغل التطبيق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Applix",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Apply",
+        "translations": [
+            "تطبيق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Appointment",
+        "translations": [
+            "موعد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Approval",
+        "translations": [
+            "إقرار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Approve",
+        "translations": [
+            "إقرار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Approved",
+        "translations": [
+            "مصادق عليه"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Approximate",
+        "translations": [
+            "تقريبي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Approximation algorithm",
+        "translations": [
+            "خوارزمية تقريب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Arabisation",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Arabization",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Arbitrary",
+        "translations": [
+            "كيفي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Arc",
+        "translations": [
+            "قوس"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Architecture",
+        "translations": [
+            "بُنية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Archive",
+        "translations": [
+            "أرشيف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Archive site",
+        "translations": [
+            "موقع أرشيفي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Archiving",
+        "translations": [
+            "أرشفة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Area",
+        "translations": [
+            "منطقة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Area grid",
+        "translations": [
+            "مربعات المساحة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Arena",
+        "translations": [
+            "حلبة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Argument",
+        "translations": [
+            "مُعطى"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Arity",
+        "translations": [
+            "رتبية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Arrange",
+        "translations": [
+            "ترتيب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Arrangement",
+        "translations": [
+            "ترتيبة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Array",
+        "translations": [
+            "مصفوفة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Arrow",
+        "translations": [
+            "سهم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Arrowhead",
+        "translations": [
+            "رأس سهم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Arrow key",
+        "translations": [
+            "مفتاح السهم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Article",
+        "translations": [
+            "مقالة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Artifact",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Artificial intelligence",
+        "translations": [
+            "ذكاء اصطناعي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Artificial neural network",
+        "translations": [
+            "شبكة عصبية اصطناعية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Artwork",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Ascender",
+        "translations": [
+            "صاعد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Ascending",
+        "translations": [
+            "تصاعدي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Ascending order",
+        "translations": [
+            "ترتيب تصاعدي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Ascii",
+        "translations": [
+            "أسكي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Aspect",
+        "translations": [
+            "مظهر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Aspect-oriented programming",
+        "translations": [
+            "برمجة موجهة بالمظاهر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Aspect ratio",
+        "translations": [
+            "نسبة باعيّة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Assembler",
+        "translations": [
+            "مُجمِّع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Assembly code",
+        "translations": [
+            "شفرة تجميع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Assembly language",
+        "translations": [
+            "لغة تجميعية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Asserted",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Assertion",
+        "translations": [
+            "توكيد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Asset management",
+        "translations": [
+            "تسيير الممتلكات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Assign",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Assignment",
+        "translations": [
+            "إسناد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Assignment problem",
+        "translations": [
+            "مسألة تعيين (برمجة)"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Assistant",
+        "translations": [
+            "مساعد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Associative array",
+        "translations": [
+            "مصفوفة ترابطية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Associative memory",
+        "translations": [
+            "ذاكرة ترابطية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Asterisk",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Asymmetric",
+        "translations": [
+            "لامُتناظِر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Asymmetrical",
+        "translations": [
+            "لا تناظري"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Asymmetrical modulation",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Asynchronous",
+        "translations": [
+            "لا تزامني"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Asynchronous logic",
+        "translations": [
+            "منطق لا تزامني"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Atom",
+        "translations": [
+            "ذرة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Atomic",
+        "translations": [
+            "ذري"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Atomicity",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "At sign",
+        "translations": [
+            "العلامة @"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Attach",
+        "translations": [
+            "إرفاق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Attachment",
+        "translations": [
+            "مرفق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Attempt",
+        "translations": [
+            "محاولة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Attribute",
+        "translations": [
+            "خاصية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Audio",
+        "translations": [
+            "سمعي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Audiographic",
+        "translations": [
+            "سمعي تخطيطي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Audiographic teleconferencing",
+        "translations": [
+            "اجتماع سمعي تخطيطي عن بعد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Audit",
+        "translations": [
+            "تدقيق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Authenticate",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Authentication",
+        "translations": [
+            "استيثاق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Authentication ticket",
+        "translations": [
+            "قسيمة استيثاق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Authenticity",
+        "translations": [
+            "صحة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Authentify",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Author",
+        "translations": [
+            "مؤلف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Authorization",
+        "translations": [
+            "تصريح"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Authorize",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Auto",
+        "translations": [
+            "آلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Autocompletion",
+        "translations": [
+            "اتمام تلقائي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Autoconfiguration",
+        "translations": [
+            "ضبط آلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Autodetect",
+        "translations": [
+            "كشف آلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Autofill",
+        "translations": [
+            "ملء آلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Autoloader",
+        "translations": [
+            "محمّل آلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Automata theory",
+        "translations": [
+            "نظرية الآلات الذاتية التشغيل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Automated testing",
+        "translations": [
+            "اختبار آلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Automatic",
+        "translations": [
+            "آلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Automatically",
+        "translations": [
+            "آليا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Automation",
+        "translations": [
+            "تشغيل آلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Automaton",
+        "translations": [
+            "مشتغل آلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Autotrace",
+        "translations": [
+            "تتبع آلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Auxiliary",
+        "translations": [
+            "إضافي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Auxiliary storage",
+        "translations": [
+            "تخزين إضافي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Availability",
+        "translations": [
+            "توفر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Available",
+        "translations": [
+            "متوفر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Avatar",
+        "translations": [
+            "أفتار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Average",
+        "translations": [
+            "متوسط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Average seek time",
+        "translations": [
+            "مدة بحث متوسطة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Away",
+        "translations": [
+            "غائب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Away message",
+        "translations": [
+            "رسالة غياب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Axial",
+        "translations": [
+            "محوري"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Axiom",
+        "translations": [
+            "بديهية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Axiomatic semantics",
+        "translations": [
+            "دلاليات بديهية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Axiomatic set theory",
+        "translations": [
+            "نظرية المجموعات البديهية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Axis",
+        "translations": [
+            "محور"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Babbleprint",
+        "translations": [
+            "بصمة منطوقة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Back",
+        "translations": [
+            "رجوع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backbone",
+        "translations": [
+            "عِماد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backbone site",
+        "translations": [
+            "موقع عمادي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Back door",
+        "translations": [
+            "مدخل سري للنظام"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Back-end",
+        "translations": [
+            "نهاية خلفية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backend",
+        "translations": [
+            "منتهى خلفي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Background",
+        "translations": [
+            "خلفية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Background directory",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Background processing",
+        "translations": [
+            "معالجة في الخلفية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Back link",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Backlog",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Backport",
+        "translations": [
+            "حمل عكسي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Back-propagation",
+        "translations": [
+            "انتشار خلفي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Back quote",
+        "translations": [
+            "فاصلة عليا مائلة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backronym",
+        "translations": [
+            "اسم موجز عكسيا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backside cache",
+        "translations": [
+            "مخَبأ خلفي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backslash",
+        "translations": [
+            "خط مائل عكسي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backspace",
+        "translations": [
+            "فراغ للخلف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backtick",
+        "translations": [
+            "فاصلة عليا مائلة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backtrace",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Backtracking",
+        "translations": [
+            "تتبع خلفي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backup",
+        "translations": [
+            "احتياطي",
+            "نسخ احتياطي",
+            "نسخة احتياطية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backup rotation",
+        "translations": [
+            "تعاقب احتياطي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backup software",
+        "translations": [
+            "برنامج احتياط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backward analysis",
+        "translations": [
+            "تحليل إلى الخلف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backward chaining",
+        "translations": [
+            "صَفد إلى الخلف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backward compatibility",
+        "translations": [
+            "توافق الإصدارات السابقة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Backward compatible",
+        "translations": [
+            "متوافق خلفيا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Balance",
+        "translations": [
+            "توازن"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Ban",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Bandwidth",
+        "translations": [
+            "حيز النطاق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Banner",
+        "translations": [
+            "لافتة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bar",
+        "translations": [
+            "شريط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bareword",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Base",
+        "translations": [
+            "أساس :: قاعدة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Baseband",
+        "translations": [
+            "نطاق أساسي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Base class",
+        "translations": [
+            "صنف أساسي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Baseline",
+        "translations": [
+            "خط أساسي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Base memory",
+        "translations": [
+            "ذاكرة أساسية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Basename",
+        "translations": [
+            "اسم أساسي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Batch",
+        "translations": [
+            "دُفعة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Batcher",
+        "translations": [
+            "معالج دفعات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Batch file",
+        "translations": [
+            "ملف الدُفعات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Batching",
+        "translations": [
+            "تدفيع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Batch processing",
+        "translations": [
+            "معالجة بالدفعات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Battery",
+        "translations": [
+            "بطارية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Baud",
+        "translations": [
+            "بود"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Baud rate",
+        "translations": [
+            "معدل الباود"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bay",
+        "translations": [
+            "فتحة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Beam",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Beamer",
+        "translations": [
+            "باث"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Beam search",
+        "translations": [
+            "بحث دعاميع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Beep",
+        "translations": [
+            "صفير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Beeper",
+        "translations": [
+            "مصفّر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Behavior",
+        "translations": [
+            "سلوك"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bell",
+        "translations": [
+            "جرس"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bell curve",
+        "translations": [
+            "منحنى جرسي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Benchmark",
+        "translations": [
+            "قياس الأداء"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Best effort",
+        "translations": [
+            "أفضل جهد (خدمة ...)"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Beta",
+        "translations": [
+            "بيتا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Beta abstraction",
+        "translations": [
+            "تجريد بيتا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Beta conversion",
+        "translations": [
+            "تحويل بيتا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Beta reduction",
+        "translations": [
+            "اختزال بيتا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Beta testing",
+        "translations": [
+            "اختبار بيتا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Beta version",
+        "translations": [
+            "إصدار بيتا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bibliography",
+        "translations": [
+            "المراجع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bidi",
+        "translations": [
+            "ثنائية الاتجاه"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "BiDi",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Bidirectional printing",
+        "translations": [
+            "طباعة ثنائية الاتجاه"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Big-endian",
+        "translations": [
+            "طرفي-كبير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bijection",
+        "translations": [
+            "تقابل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bilinear patch",
+        "translations": [
+            "رقعة ثنائية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Binary",
+        "translations": [
+            "ثنائي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Binary coded decimal",
+        "translations": [
+            "عشري مرمَّز ثنائيا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Binary exponential backoff",
+        "translations": [
+            "رقود أسي ثنائي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Binary large object",
+        "translations": [
+            "كائن ثنائي ضخم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Binary package",
+        "translations": [
+            "حزمة ثنائية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Binary search",
+        "translations": [
+            "بحث ثنائي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Binary tree",
+        "translations": [
+            "شجرة ثنائية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bind",
+        "translations": [
+            "ربط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Binding",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Binding handle",
+        "translations": [
+            "مقبض ارتباط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Binding-time analysis",
+        "translations": [
+            "تحليل وقت الارتباط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "BIOS",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Bipolar",
+        "translations": [
+            "ثنائي القطب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bit",
+        "translations": [
+            "بِتة :: ثنائية :: ذرة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bit block transfer",
+        "translations": [
+            "نقل كتلة بت"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bit depth",
+        "translations": [
+            "عمق البِت"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bit gravity",
+        "translations": [
+            "جاذبية البِت"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bitmap",
+        "translations": [
+            "خارطة ثنائية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bitmap display",
+        "translations": [
+            "عرض نقطي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bitmap font",
+        "translations": [
+            "خط نقطي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bit mask",
+        "translations": [
+            "قناع البت"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bit pattern",
+        "translations": [
+            "متسلسلة ثنائية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bit plane",
+        "translations": [
+            "مسطح ثنائية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bit rate",
+        "translations": [
+            "معدل البت"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bit slice",
+        "translations": [
+            "شريحة ثنائيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bit string",
+        "translations": [
+            "سلسلة ثنائيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bitwise",
+        "translations": [
+            "بتّي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bitwise complement",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Blacklist",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Blank",
+        "translations": [
+            "فارغ",
+            "فراغ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Blend",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Blending",
+        "translations": [
+            "مزج"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Blink",
+        "translations": [
+            "وميض"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Blinking cursor",
+        "translations": [
+            "مؤشر نابض"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bloat",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Block",
+        "translations": [
+            "صدّ :: حظر :: كتلة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Block buffer",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Blocked",
+        "translations": [
+            "ممنوع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Blocked record",
+        "translations": [
+            "تسجيلة مكتَّلة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Block-structured",
+        "translations": [
+            "ذو بنية كُتل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Block (unit)",
+        "translations": [
+            "كتلة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Block (verb)",
+        "translations": [
+            "تجميد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Blog",
+        "translations": [
+            "مدوّنة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Blogosphere",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Bluetooth",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Blur",
+        "translations": [
+            "ضبابية (رسم) :: عدم وضوح"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Blu-ray",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Blur image",
+        "translations": [
+            "صورة غائمة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Board",
+        "translations": [
+            "لوحة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Body",
+        "translations": [
+            "متن"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bogon filter",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Bold",
+        "translations": [
+            "ثخين"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bolt",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Boo",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Book",
+        "translations": [
+            "كتاب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Book mark",
+        "translations": [
+            "علامة موقع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bookmark",
+        "translations": [
+            "علامة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Boolean",
+        "translations": [
+            "منطقي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Boot",
+        "translations": [
+            "إقلاع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Boot block",
+        "translations": [
+            "كتلة إقلاع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Boot image",
+        "translations": [
+            "صورة إقلاع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Booting",
+        "translations": [
+            "إقلاع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Boot loader",
+        "translations": [
+            "محمّل الإقلاع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bootloader",
+        "translations": [
+            "محمّل إقلاع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bootrom",
+        "translations": [
+            "ذقف إقلاع (ذاكرة إقلاع مقروءة فقط)"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Boot server",
+        "translations": [
+            "خادم إقلاع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bootstrap",
+        "translations": [
+            "نظام تمهيد تشغيل الكمبيوتر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bootstrap loader",
+        "translations": [
+            "محمّل إقلاع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Boot virus",
+        "translations": [
+            "فايروس إقلاع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Border",
+        "translations": [
+            "حد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bot",
+        "translations": [
+            "آلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bottom",
+        "translations": [
+            "أسفل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bottom-unique",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Bounce",
+        "translations": [
+            "يرتد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bounce message",
+        "translations": [
+            "رسالة وُثوب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bound",
+        "translations": [
+            "مُقَيَّد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Boundary scan",
+        "translations": [
+            "مسح حدودي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Boundary value analysis",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Bounded",
+        "translations": [
+            "مُتَنَاه",
+            "مَحْدُود"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Boundedly complete",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Bounding box",
+        "translations": [
+            "مربع إحاطة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bound variable",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Box",
+        "translations": [
+            "صندوق",
+            "مربع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Boxed comment",
+        "translations": [
+            "تعليق مربع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bpp",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Brace",
+        "translations": [
+            "حاصرة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bracket",
+        "translations": [
+            "قوس"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bracket abstraction",
+        "translations": [
+            "تجريد الأقواس"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Braille",
+        "translations": [
+            "برايل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Branch",
+        "translations": [
+            "فرع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Branch coverage testing",
+        "translations": [
+            "اختبار تغطية التفرّع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Branch delay slot",
+        "translations": [
+            "فتحة تمهيل التفرّع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Branch prediction",
+        "translations": [
+            "توقع التفرّع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Brand",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Breadth-first search",
+        "translations": [
+            "البحث بالعرض أولا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Break",
+        "translations": [
+            "كسر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Break point",
+        "translations": [
+            "نقطة انقطاع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Breakpoint",
+        "translations": [
+            "نقطة المقاطعة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Break (program)",
+        "translations": [
+            "انقطاع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Break statement",
+        "translations": [
+            "عبارة انقطاع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bricks",
+        "translations": [
+            "طوب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bridge",
+        "translations": [
+            "جسر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bridge (noun)",
+        "translations": [
+            "جسر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bridge (verb)",
+        "translations": [
+            "جَسر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Briefcase",
+        "translations": [
+            "حقيبة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Brightness",
+        "translations": [
+            "السطوع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Broadband",
+        "translations": [
+            "نطاق ترددي واسع",
+            "نطاق واسع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Broadcast",
+        "translations": [
+            "بث"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Broadcast quality video",
+        "translations": [
+            "مرئية ذات جودة إذاعية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Brochure",
+        "translations": [
+            "كتيب :: كرّاسة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Broken",
+        "translations": [
+            "معطوب",
+            "مكسور"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Broken line",
+        "translations": [
+            "خط مقطوع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Browse",
+        "translations": [
+            "تصفّح"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Browser",
+        "translations": [
+            "متصفح"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Brush",
+        "translations": [
+            "فرشاة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Brute force",
+        "translations": [
+            "قوة قاسية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Brute force attack",
+        "translations": [
+            "هجوم بالقوة القاسية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "BTP",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Bubble",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Buddy",
+        "translations": [
+            "صاحب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Buffer",
+        "translations": [
+            "صِوان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Buffered write-through",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Buffering",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Buffer overflow",
+        "translations": [
+            "طوفان الصِوان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bug",
+        "translations": [
+            "علَّة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bug fix",
+        "translations": [
+            "إصلاح خلل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bug fix release",
+        "translations": [
+            "إصدار مصلِح"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bug tracking system",
+        "translations": [
+            "نظام متابعة خلال"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Build",
+        "translations": [
+            "بناء"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Built-in",
+        "translations": [
+            "مضمّن"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bullet",
+        "translations": [
+            "رصاصة",
+            "كرية تعداد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bulletin Board",
+        "translations": [
+            "ساحة نقاش"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bulletin board system",
+        "translations": [
+            "نظام لوحة النشرات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bullet list",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Bundle",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Bundled",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Burn",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Bus",
+        "translations": [
+            "ناقل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bus arbitration",
+        "translations": [
+            "حكم النواقل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bus cycle",
+        "translations": [
+            "دورة نواقل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bus device",
+        "translations": [
+            "جهاز ناقل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bus error",
+        "translations": [
+            "خطأ ناقل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Business to business",
+        "translations": [
+            "متاجرة بين عمل وعمل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bus master",
+        "translations": [
+            "رئيس نواقل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bus mastering",
+        "translations": [
+            "رئاسة نواقل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bus network",
+        "translations": [
+            "شبكة خطّية",
+            "شبكة مسروية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bus priority",
+        "translations": [
+            "أولوية نواقل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bus request",
+        "translations": [
+            "طلب ناقل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bus sizing",
+        "translations": [
+            "تحجيم نواقل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bus watcher",
+        "translations": [
+            "مراقب الناقل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Busy",
+        "translations": [
+            "مشغول"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Button",
+        "translations": [
+            "زر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Button binding",
+        "translations": [
+            "ربط أزرار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Button grab",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Buzz",
+        "translations": [
+            "بزبز"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Bypass",
+        "translations": [
+            "تجاوز"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Byte",
+        "translations": [
+            "بايت :: جزئ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Byte addressing",
+        "translations": [
+            "عنونة ثمانيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Byte-code",
+        "translations": [
+            "شفرةٌ ثمانية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Byte-code compiler",
+        "translations": [
+            "مترجم شفرة ثمانية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Byte-code interpreter",
+        "translations": [
+            "مؤوّل شفرة ثمانية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Byte compiler",
+        "translations": [
+            "مترجم شفرة ثمانية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Byte order",
+        "translations": [
+            "ترتيب ثمانيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "C",
+        "translations": [
+            "سي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cable",
+        "translations": [
+            "كبل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cable modem",
+        "translations": [
+            "كبل المودم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cache",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cache block",
+        "translations": [
+            "كتلة مَخبأ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cache coherency",
+        "translations": [
+            "تماسك مَخبأ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cache conflict",
+        "translations": [
+            "تعارض في مَخبأ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cache consistency",
+        "translations": [
+            "تماسك مَخبأ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cache controller",
+        "translations": [
+            "متحكم مَخبأ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cache hit",
+        "translations": [
+            "إصابة مَخبأ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cache lease",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cache line",
+        "translations": [
+            "سطر مَخبأ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cache memory",
+        "translations": [
+            "مَخبأ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cache miss",
+        "translations": [
+            "إخطاء مَخبأ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Caching",
+        "translations": [
+            "تخزين مؤقت"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Caching-only",
+        "translations": [
+            "خَبء فقط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Caching server",
+        "translations": [
+            "خادم تخبئة",
+            "خادم خَبء"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "CAD",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Calculate",
+        "translations": [
+            "حساب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Calculation",
+        "translations": [
+            "حساب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Calculator",
+        "translations": [
+            "حاسبة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Calendar",
+        "translations": [
+            "تقويم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Calibration",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Call",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Callback",
+        "translations": [
+            "رد نداء (نظام)"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Call-by-name",
+        "translations": [
+            "نداء بالاسم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Call-by-need",
+        "translations": [
+            "نداء بالحاجة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Call-by-reference",
+        "translations": [
+            "نداء بالمرجع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Call-by-value",
+        "translations": [
+            "نداء بالقيمة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Call-by-value-result",
+        "translations": [
+            "نداء بنتيجة القيمة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Callee",
+        "translations": [
+            "منادى"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Calling convention",
+        "translations": [
+            "اتفاق نداء"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Callout",
+        "translations": [
+            "نداء"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Call-with-current-continuation",
+        "translations": [
+            "نداء بالمواصلة الحالية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Camera",
+        "translations": [
+            "كامرة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cancel",
+        "translations": [
+            "إلغاء"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Candidate key",
+        "translations": [
+            "مفتاح مرشَّح"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Canonical",
+        "translations": [
+            "قانوني"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Canonical name",
+        "translations": [
+            "اسم متعارف عليه"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Canonicity",
+        "translations": [
+            "قانونية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Canvas",
+        "translations": [
+            "رقعة (الرسم)"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Capability",
+        "translations": [
+            "قدرة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Capacity",
+        "translations": [
+            "سعة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Caps",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Caption",
+        "translations": [
+            "شرح لوحة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Capture",
+        "translations": [
+            "التقاط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Captured image",
+        "translations": [
+            "صورة ملتقطَة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Card",
+        "translations": [
+            "بطاقة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Card cage",
+        "translations": [
+            "قفص بطاقات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cardinality",
+        "translations": [
+            "رئيسي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cardinal number",
+        "translations": [
+            "عدد أصلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Card slot",
+        "translations": [
+            "فتحة بطاقات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Caret",
+        "translations": [
+            "قبعة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Carriage return",
+        "translations": [
+            "رجوع إلى السطر",
+            "مُرجع إلى السطر (مِحرف)"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Carrier",
+        "translations": [
+            "حامل",
+            "ناقل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Carrier scanner",
+        "translations": [
+            "ماسحة حوامل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Carrier signal",
+        "translations": [
+            "إشارة حاملة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cartesian coordinates",
+        "translations": [
+            "إحداثيات ديكارتية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cartesian product",
+        "translations": [
+            "جداء ديكارتي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cartridge",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cascade",
+        "translations": [
+            "تتالي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cascaded list",
+        "translations": [
+            "قائمة مدرَّجة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cascading style sheet",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Case",
+        "translations": [
+            "حالة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Case based reasoning",
+        "translations": [
+            "تفكير مبنٍ على الأمثلة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Case (font)",
+        "translations": [
+            "حالة (الحرف)",
+            "كبر (حروف)"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Case insensitive",
+        "translations": [
+            "غير متأثر بكِبر الحروف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Case-sensitive",
+        "translations": [
+            "مميِّز لحالة الأحرف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Case Sensitive",
+        "translations": [
+            "حساس لحالة الحرف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Case sensitivity",
+        "translations": [
+            "تأثر بكِبر الحروف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Case statement",
+        "translations": [
+            "عبارةُ حالة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cast",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Casting",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Catalog",
+        "translations": [
+            "كتالوج",
+            "مسرد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Catch-all",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Catch-all-entry",
+        "translations": [
+            "قبض كل المداخل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Categories",
+        "translations": [
+            "تصنيفات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Category",
+        "translations": [
+            "فئة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Catenet",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cathode ray tube",
+        "translations": [
+            "أنبوب حزات كاثودي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cationic cocktail",
+        "translations": [
+            "محلول كاتيوني"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cause-effect graphing",
+        "translations": [
+            "تخطيط سببي مسببي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "CC",
+        "translations": [
+            "(١) نسخة كربونية؛ (٢) مناسخة؛ (٣) يناسخ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "CD",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "CDE panel",
+        "translations": [
+            "لوحة تحكم CDE"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "CD-ROM",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cell",
+        "translations": [
+            "خلية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cell encoding",
+        "translations": [
+            "ترميز الخلايا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cellphone",
+        "translations": [
+            "هاتف خلوي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cellular",
+        "translations": [
+            "خلوي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cellular automata",
+        "translations": [
+            "مشتغلات آلية خلوية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cellular automaton",
+        "translations": [
+            "مشتغل آلي خلوي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cellular multiprocessing",
+        "translations": [
+            "معالجة متعددة خلوية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Center",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Centered",
+        "translations": [
+            "مُوسّط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Centimeter",
+        "translations": [
+            "سنتيمتر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Central arbiter",
+        "translations": [
+            "حكم مركزي REMOVE"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Central office",
+        "translations": [
+            "مكتب مركزي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Central processing unit",
+        "translations": [
+            "وحدة المعالجة المركزية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Centum call second",
+        "translations": [
+            "مئة ثانية اتصال"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cepstrum",
+        "translations": [
+            "سبسَتروم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Certificate",
+        "translations": [
+            "شهادة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Certify",
+        "translations": [
+            "إشهاد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chad",
+        "translations": [
+            "فتات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chad box",
+        "translations": [
+            "صندوق فتات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chain",
+        "translations": [
+            "سلسلة",
+            "قيد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Change",
+        "translations": [
+            "تغيير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Change management",
+        "translations": [
+            "إدارة التغيير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Changeover",
+        "translations": [
+            "استعداد للتغيير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Channel",
+        "translations": [
+            "قناة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Channel service unit",
+        "translations": [
+            "وحدة خدمية قنوية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chaos",
+        "translations": [
+            "شواش"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chapter",
+        "translations": [
+            "فصل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Char",
+        "translations": [
+            "مِحرف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Character",
+        "translations": [
+            "مِحرف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Character device",
+        "translations": [
+            "جهاز مِحرفي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Character encoding",
+        "translations": [
+            "ترميز الأحرف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Character encoding scheme",
+        "translations": [
+            "مخطط ترميز محارف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Character graphic",
+        "translations": [
+            "رسم مِحرفي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Characteristic function",
+        "translations": [
+            "دالة مميزة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Character key",
+        "translations": [
+            "مفتاح محرفي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Character map",
+        "translations": [
+            "خريطة الأحرف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Character repertoire",
+        "translations": [
+            "مسرد محارف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Character set",
+        "translations": [
+            "مجموعة أحرف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Character set identifier",
+        "translations": [
+            "مُعرِّف طقم محارف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Character string",
+        "translations": [
+            "سلسلة محارف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Char cell",
+        "translations": [
+            "خلية مِحرف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Charityware",
+        "translations": [
+            "برنامج خيري"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Charmap",
+        "translations": [
+            "خارطة محارف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Charset",
+        "translations": [
+            "طقم محارف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chart",
+        "translations": [
+            "خُطاطة",
+            "رسم بياني"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chase pointers",
+        "translations": [
+            "مؤشر تقصّصSINGULAR"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chat",
+        "translations": [
+            "دردشة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chatchup",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Chat room",
+        "translations": [
+            "غرفة دردشة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chat script",
+        "translations": [
+            "مخطوط محادثة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Check",
+        "translations": [
+            "فحص :: تأكُّد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Check (a button)",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Check bit",
+        "translations": [
+            "بت الفحص"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Check box",
+        "translations": [
+            "صندوق تأشير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Checkbox",
+        "translations": [
+            "خانة تأشير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Checkbox menu",
+        "translations": [
+            "قائمة خيارات مربع تأشير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Checkered",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Checkout",
+        "translations": [
+            "سحب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Checkpoint",
+        "translations": [
+            "نقطة التحقق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Checksum",
+        "translations": [
+            "تدقيق المجموع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Child",
+        "translations": [
+            "بنوي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Child directory",
+        "translations": [
+            "دليل بنوي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Child process",
+        "translations": [
+            "عملية بنوية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Child record",
+        "translations": [
+            "تسجيلة بنوية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Child status",
+        "translations": [
+            "حالة بنوية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Child structure",
+        "translations": [
+            "بنية بنوية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Child version",
+        "translations": [
+            "نسخة بنوية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Child window",
+        "translations": [
+            "إطار فرعي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chip",
+        "translations": [
+            "رقاقة [رقاقات]"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chip box",
+        "translations": [
+            "صندوق فتات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chip set",
+        "translations": [
+            "مجموعة شرائح"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chmod",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Choice",
+        "translations": [
+            "اختيار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Choose",
+        "translations": [
+            "اختيار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chooser",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Chroma",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Chroma key",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Chromatic number",
+        "translations": [
+            "عدد لوني"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Chrome",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Chrominance",
+        "translations": [
+            "الكروماتية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cipher",
+        "translations": [
+            "شيفرة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Ciphertext",
+        "translations": [
+            "نص مشفّر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Circle",
+        "translations": [
+            "دائرة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Circuit",
+        "translations": [
+            "دارة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Circuit switched",
+        "translations": [
+            "دوريً الإبدال"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Circuit switching",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Circular buffer",
+        "translations": [
+            "مَحفظ دوري"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Circumflex",
+        "translations": [
+            "قبعة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Citizen journalism",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Class",
+        "translations": [
+            "صنف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Class hierarchy",
+        "translations": [
+            "سلالة أصناف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Classic",
+        "translations": [
+            "اعتيادي",
+            "تقليدي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Classical logic",
+        "translations": [
+            "منطق تقليدي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Classification",
+        "translations": [
+            "تصنيف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Classify",
+        "translations": [
+            "تصنيف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Class library",
+        "translations": [
+            "مكتبة أصناف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Class method",
+        "translations": [
+            "طريقة صنفية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Classpath",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Class variable",
+        "translations": [
+            "متغير صنف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clause",
+        "translations": [
+            "بند"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clean",
+        "translations": [
+            "تنظيف",
+            "نظيف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clear",
+        "translations": [
+            "محو"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clear box testing",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Click",
+        "translations": [
+            "نقْر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Click (noun)",
+        "translations": [
+            "نقرة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Click (verb)",
+        "translations": [
+            "نقر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Client",
+        "translations": [
+            "عميل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Client-server",
+        "translations": [
+            "عميل وخادوم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Client-server model",
+        "translations": [
+            "نموذج عميل وخادم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Client-side",
+        "translations": [
+            "من جهة العميل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clip art",
+        "translations": [
+            "قصاصة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clipart",
+        "translations": [
+            "قصاصة فنية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clip board",
+        "translations": [
+            "لوحة قصاصات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clipboard",
+        "translations": [
+            "حافظة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clip list",
+        "translations": [
+            "قائمة قصاصات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clip mask",
+        "translations": [
+            "قناع قصاصة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clipping",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Clipping plane",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Clock",
+        "translations": [
+            "ساعة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clock rate",
+        "translations": [
+            "سرعة ساعة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clock speed",
+        "translations": [
+            "سرعة الميقاتية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clone",
+        "translations": [
+            "استنساخ",
+            "مستنسخ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clone device",
+        "translations": [
+            "جهاز مستنسخ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Close",
+        "translations": [
+            "إغلاق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Closed set",
+        "translations": [
+            "مجموعة مغلقة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Closed surface",
+        "translations": [
+            "مساحة مغلقة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Closed term",
+        "translations": [
+            "حد مغلق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Close routine",
+        "translations": [
+            "وتيرة إغلاق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Closure",
+        "translations": [
+            "إغلاق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Closure conversion",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cloud computing",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Clover key",
+        "translations": [
+            "مفتاح نفل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clumsy",
+        "translations": [
+            "طائش"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cluster",
+        "translations": [
+            "خصلة",
+            "عنقود"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cluster file",
+        "translations": [
+            "ملف حشد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Clustering",
+        "translations": [
+            "حشد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cluster member",
+        "translations": [
+            "عضو حشد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cluster node",
+        "translations": [
+            "عقدة خصيلة",
+            "عقدة عنقود"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cluster-transport",
+        "translations": [
+            "نقل حشد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Coalesced sum",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Coarse grain",
+        "translations": [
+            "حبً خشن"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Coax",
+        "translations": [
+            "كبل متحد المحور"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Coaxial",
+        "translations": [
+            "متحد المحور"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Coaxial cable",
+        "translations": [
+            "موصل محوري"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cocktail shaker sort",
+        "translations": [
+            "فرز خلاط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Code",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Codebase",
+        "translations": [
+            "قاعدة شفرة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Codec",
+        "translations": [
+            "مرماز"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Coded character set",
+        "translations": [
+            "طقم محارف مرمّز"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Code division multiplexing",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Code folding",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Code management",
+        "translations": [
+            "تسيير شفرة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Code position",
+        "translations": [
+            "موضع رمز"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Code (program)",
+        "translations": [
+            "شفرة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Code segment",
+        "translations": [
+            "قطعة شفرة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Code (symbol)",
+        "translations": [
+            "رمز"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Code violation",
+        "translations": [
+            "خرق (قواعد) الرماز"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Code walk",
+        "translations": [
+            "مراجعة شفرة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Codomain",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Coefficient",
+        "translations": [
+            "معامل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cognitive architecture",
+        "translations": [
+            "عمارة إدراكية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Collaboration",
+        "translations": [
+            "تعاون"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Collapse",
+        "translations": [
+            "طي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Collate",
+        "translations": [
+            "رزم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Collect",
+        "translations": [
+            "التقاط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Collection",
+        "translations": [
+            "مجموعة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Collision",
+        "translations": [
+            "تصادم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Collision detection",
+        "translations": [
+            "كشف تصادمات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Colocation",
+        "translations": [
+            "توصيل شبكي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Colon",
+        "translations": [
+            "نقطتان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Colophon",
+        "translations": [
+            "حرد المتن"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Color",
+        "translations": [
+            "لون"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Color chooser",
+        "translations": [
+            "مخيِّر ألوان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Color map",
+        "translations": [
+            "مخطط الألوان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Colormap",
+        "translations": [
+            "مخطط ألوان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Color model",
+        "translations": [
+            "نموذج ألوان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Color saturation",
+        "translations": [
+            "إشباع ألوان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Colour",
+        "translations": [
+            "لون"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Colour depth",
+        "translations": [
+            "عمق ألوان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Colour look-up table",
+        "translations": [
+            "جدول بحث عن الألوان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Colour model",
+        "translations": [
+            "نموذج ألوان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Colour palette",
+        "translations": [
+            "لوحة ألوان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Column",
+        "translations": [
+            "عمود"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Column span",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Combination",
+        "translations": [
+            "تجميعة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Combinator",
+        "translations": [
+            "دالة توافقية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Combinatory logic",
+        "translations": [
+            "منطق توافقي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Combo box",
+        "translations": [
+            "مربع تحرير وسرد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Combobox",
+        "translations": [
+            "مربع مركب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Comma",
+        "translations": [
+            "فاصلة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Command",
+        "translations": [
+            "أمر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Command button",
+        "translations": [
+            "زر أمر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Command interpreter",
+        "translations": [
+            "مؤول أوامر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Command key",
+        "translations": [
+            "مفتاح أمر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Command line",
+        "translations": [
+            "سطر الأوامر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Commandline",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Command line interface",
+        "translations": [
+            "واجهة سطر الأوامر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Command-line interpreter",
+        "translations": [
+            "مؤول سطر أوامر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Command line option",
+        "translations": [
+            "خيار سطر أوامر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Command line options",
+        "translations": [
+            "خيارات سطر الأوامر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Command Prompt",
+        "translations": [
+            "محث أوامر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Comma separated values",
+        "translations": [
+            "قيم مفصولة بفواصل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Comment",
+        "translations": [
+            "تعليق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Comment out",
+        "translations": [
+            "إزالة تعليق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Commercial a",
+        "translations": [
+            "علامة عند"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Commit",
+        "translations": [
+            "إيداع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Common",
+        "translations": [
+            "شائع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Common carrier",
+        "translations": [
+            "حامل اعتيادي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Common factor",
+        "translations": [
+            "عامل مشترك"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Common properties",
+        "translations": [
+            "خصائص عامة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Communication",
+        "translations": [
+            "تواصل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Communication system",
+        "translations": [
+            "نظام اتصال"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compact",
+        "translations": [
+            "مُدْمج"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compact disc",
+        "translations": [
+            "قرص مدمج"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compaction",
+        "translations": [
+            "ضغط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compactness preserving",
+        "translations": [
+            "حفظ تضام"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Company",
+        "translations": [
+            "الشركة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compare",
+        "translations": [
+            "مقارنة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compatibility",
+        "translations": [
+            "توافق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compatible",
+        "translations": [
+            "متوافق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compilation",
+        "translations": [
+            "تصريف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compile",
+        "translations": [
+            "تصريف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compiler",
+        "translations": [
+            "مُصرِّف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compiler compiler",
+        "translations": [
+            "مترجم مترجم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Complement",
+        "translations": [
+            "تكملة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Complete",
+        "translations": [
+            "تام"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Complete graph",
+        "translations": [
+            "تخطيطة كاملة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Complete inference system",
+        "translations": [
+            "نظام استنباط كامل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Complete lattice",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Complete metric space",
+        "translations": [
+            "فضاء متري كامل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Completeness",
+        "translations": [
+            "كمول"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Complete partial ordering",
+        "translations": [
+            "ترتيب جزئي كامل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Complete theory",
+        "translations": [
+            "نظرية كمول"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Complete unification",
+        "translations": [
+            "توحيد كامل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Complexity",
+        "translations": [
+            "تعقّد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Complexity analysis",
+        "translations": [
+            "تحليل تعقّد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Complexity class",
+        "translations": [
+            "صنف تعقد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Complexity measure",
+        "translations": [
+            "قياس تعقد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Complex number",
+        "translations": [
+            "عدد مركّب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Complex programmable logic device",
+        "translations": [
+            "جهاز منطقي معقد قابلة للtranslated"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Component",
+        "translations": [
+            "مكوّن"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Component architecture",
+        "translations": [
+            "عمارة مكوّنية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Component based development",
+        "translations": [
+            "تطوير مبنٍ على المكونات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Component video",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Compose",
+        "translations": [
+            "تركيب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Composite",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Composite cable",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Composite drive",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Composite video",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Composition",
+        "translations": [
+            "تركيب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compound command",
+        "translations": [
+            "أمر مركب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compound key",
+        "translations": [
+            "مفتاح مركَّب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compress",
+        "translations": [
+            "ضغط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compressed",
+        "translations": [
+            "مضغوط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compressed video",
+        "translations": [
+            "مرئية مضغوطة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compressibilty factor",
+        "translations": [
+            "عامل الإنضِغاط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compression",
+        "translations": [
+            "ضغط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computability theory",
+        "translations": [
+            "نظرية تحسيب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computable",
+        "translations": [
+            "قابل للتحسيب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computational complexity",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Computational geometry",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Computational learning",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Computational molecular biology",
+        "translations": [
+            "بيولوجيا جزيئية حاسوبية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computational organochemistry",
+        "translations": [
+            "كيمياء عضوية حاسوبية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compute",
+        "translations": [
+            "حساب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computer",
+        "translations": [
+            "حاسوب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computer algebra system",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Computer cluster",
+        "translations": [
+            "عنقود حاسوبي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computer cookie",
+        "translations": [
+            "حلوى حاسوب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computer ethics",
+        "translations": [
+            "أخلاقيات حاسوب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computer-generated imagery",
+        "translations": [
+            "تصوير مولد بالحاسوب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computer language",
+        "translations": [
+            "لغة الحاسوب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computer law",
+        "translations": [
+            "قانون حاسوب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computer literacy",
+        "translations": [
+            "إلمام بالحاسوب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computer network",
+        "translations": [
+            "شبكة حواسب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computer program",
+        "translations": [
+            "برنامج حاسوب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computer security",
+        "translations": [
+            "أمن الكمبيوتر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computer virus",
+        "translations": [
+            "فيروس حاسوبي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computer vision",
+        "translations": [
+            "بصر حاسوبي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Compute server",
+        "translations": [
+            "خادم حساب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computing",
+        "translations": [
+            "حوسبة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Computron",
+        "translations": [
+            "حاسوبون"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Concatenate",
+        "translations": [
+            "لمّ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Concatenated key",
+        "translations": [
+            "مفتاح ملموم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Concentrator",
+        "translations": [
+            "مركِّز"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Conceptualisation",
+        "translations": [
+            "مفهمة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Concrete class",
+        "translations": [
+            "فئة محددة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Concrete syntax",
+        "translations": [
+            "نحو مادي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Concurrency",
+        "translations": [
+            "تزامن"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Concurrent",
+        "translations": [
+            "متزامن",
+            "مرافق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Concurrent processing",
+        "translations": [
+            "معالجة منافسة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Condense",
+        "translations": [
+            "تكثيف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Condensed",
+        "translations": [
+            "مكثف",
+            "موجز"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Condition",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Condition out",
+        "translations": [
+            "تفريغ شرط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Conduit",
+        "translations": [
+            "مجرى"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cone",
+        "translations": [
+            "مخروط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Confidence test",
+        "translations": [
+            "اختبار ثقة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Confidential",
+        "translations": [
+            "سرّي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Configuration",
+        "translations": [
+            "تضبيط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Configuration item",
+        "translations": [
+            "عنصر تشكيل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Configuration management",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Configuration programming",
+        "translations": [
+            "برمجة تشكيل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Configure",
+        "translations": [
+            "ضبط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Confirm",
+        "translations": [
+            "تأكيد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Confirmation",
+        "translations": [
+            "تأكيد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Conflation",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Conflict",
+        "translations": [
+            "تضارب",
+            "تناقض"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Congestion",
+        "translations": [
+            "احتقان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Conjunction",
+        "translations": [
+            "اقتران"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Connect",
+        "translations": [
+            "اتصال"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Connected graph",
+        "translations": [
+            "مبيان متصل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Connected subgraph",
+        "translations": [
+            "مبيان فرعي متصل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Connection",
+        "translations": [
+            "اتصال"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Connectionless protocol",
+        "translations": [
+            "ميفاق بدون اتصال"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Connection-oriented",
+        "translations": [
+            "موجّه بالاتصال"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Connection-oriented network service",
+        "translations": [
+            "خدمة شبكية موجّهة بالاتصال"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Connection pool",
+        "translations": [
+            "مَجمع اتصالات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Connective",
+        "translations": [
+            "إتصالي",
+            "رابط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Connectors",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Conservative evaluation",
+        "translations": [
+            "تقييم محافظ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Consistently complete",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Console",
+        "translations": [
+            "كونسول"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Consolidate",
+        "translations": [
+            "تدعيم",
+            "توطيد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Constant",
+        "translations": [
+            "ثابت"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Constant angular velocity",
+        "translations": [
+            "سرعة زاوية ثابتة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Constant applicative form",
+        "translations": [
+            "شكل تطبيقي ثابت"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Constant folding",
+        "translations": [
+            "طي ثابت"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Constant linear velocity",
+        "translations": [
+            "سرعة خطية ثابتة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Constant mapping",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Constraint",
+        "translations": [
+            "قسْر",
+            "قيد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Constraint functional programming",
+        "translations": [
+            "برمجة وظيفية قيدية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Constraint satisfaction",
+        "translations": [
+            "إرضاء قيود"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Constructed type",
+        "translations": [
+            "نوع مبني"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Constructive",
+        "translations": [
+            "بنائي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Constructive solid geometry",
+        "translations": [
+            "هندسة صلبة بنائية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Constructor",
+        "translations": [
+            "باني"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Consultant",
+        "translations": [
+            "مستشار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Contact",
+        "translations": [
+            "مراسل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Contact (noun)",
+        "translations": [
+            "معرفة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Contact (verb)",
+        "translations": [
+            "اتصال"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Container",
+        "translations": [
+            "حاوية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Container class",
+        "translations": [
+            "صنف واعٍ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Content",
+        "translations": [
+            "محتوى"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Content addressable memory",
+        "translations": [
+            "ذاكرة ذات محتوى قابل للقصد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Content-based information retrieval",
+        "translations": [
+            "سحب معلومات مبن على المحتوى"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Contention slot",
+        "translations": [
+            "مهلة تنازع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Context",
+        "translations": [
+            "سياق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Context clash",
+        "translations": [
+            "تعارض سياق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Context-free",
+        "translations": [
+            "مستقل عن السياق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Context-free grammar",
+        "translations": [
+            "نحو مستقل عن السياق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Context object",
+        "translations": [
+            "كائن سياق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Context operator",
+        "translations": [
+            "عامل سياق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Context-sensitive",
+        "translations": [
+            "متأثر بالسياق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Context-sensitive menu",
+        "translations": [
+            "قائمة خيارات متأثرة بالسياق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Context switch",
+        "translations": [
+            "تبديل سياق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Contextual menu",
+        "translations": [
+            "قائمة خيارات سياقية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Continuation",
+        "translations": [
+            "اتصال (دالة)",
+            "استمرار",
+            "متابعة (برمجة دوال)"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Continuation passing style",
+        "translations": [
+            "أسلوب تمريرِ متابعة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Continue",
+        "translations": [
+            "استمرار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Continuous",
+        "translations": [
+            "خط)",
+            "متصل (دالة",
+            "متواصل",
+            "مستمر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Continuous function",
+        "translations": [
+            "دالة متصلة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Continuous wave",
+        "translations": [
+            "موجة متصلة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Contour",
+        "translations": [
+            "محيط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Contraction",
+        "translations": [
+            "تقليص"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Contract programmer",
+        "translations": [
+            "مبرمج تحت عقد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Contrast",
+        "translations": [
+            "تباين"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Contribution",
+        "translations": [
+            "مساهمة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Contributor",
+        "translations": [
+            "مساهِم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Control",
+        "translations": [
+            "تحكّم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Control code",
+        "translations": [
+            "رمز تحكم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Control file",
+        "translations": [
+            "ملف تحكم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Control flow",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Controller",
+        "translations": [
+            "متحكم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Control point",
+        "translations": [
+            "نُقطة التحكم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Control structure",
+        "translations": [
+            "بنية تحكم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Control unit",
+        "translations": [
+            "وحدة تحكم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Conventional memory",
+        "translations": [
+            "ذاكرة اصطلاحية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Converge",
+        "translations": [
+            "يحتشد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Convergence",
+        "translations": [
+            "إحتشاد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Conversation",
+        "translations": [
+            "محادثة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Converse",
+        "translations": [
+            "تحويل",
+            "عكس (منطق)"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Conversion",
+        "translations": [
+            "تحويل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Conversion to iteration",
+        "translations": [
+            "تحويل إلى التكرار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Convert",
+        "translations": [
+            "تحويل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Converting",
+        "translations": [
+            "تحويل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Convex hull",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cooccurrence matrix",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cookie",
+        "translations": [
+            "كعكة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cooperative",
+        "translations": [
+            "جماعي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cooperative multitasking",
+        "translations": [
+            "تعدد المهام التعاونيً"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Coordinate",
+        "translations": [
+            "تنسيق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Coordination language",
+        "translations": [
+            "لغة تنسيق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Coprocessor",
+        "translations": [
+            "معالج مساعد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Coproduct",
+        "translations": [
+            "منتوج جانبي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Copy",
+        "translations": [
+            "ينسخ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Copy and paste",
+        "translations": [
+            "إنسخ وألصق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Copying garbage collection",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Copy left",
+        "translations": [
+            "النسخ للجميع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Copyleft",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Copy (noun)",
+        "translations": [
+            "نسخ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Copy protection",
+        "translations": [
+            "حماية النسخ",
+            "حماية من النسخ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Copy right",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Copyright",
+        "translations": [
+            "حقوق النشر",
+            "محفوظ الحقوق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Copyrighted",
+        "translations": [
+            "محفوظ الحقوق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Copy (verb)",
+        "translations": [
+            "نسخة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "CORBA",
+        "translations": [
+            "كوربا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Core",
+        "translations": [
+            "لُب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Core class",
+        "translations": [
+            "فئة باطنية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Core dump",
+        "translations": [
+            "تفريغ الباطن"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Core file",
+        "translations": [
+            "ملف باطني"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Core gateway",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Core leak",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Corner",
+        "translations": [
+            "زاوِيَة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Corollary",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Corporate",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Corpus",
+        "translations": [
+            "مكنز"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Correct",
+        "translations": [
+            "صحيح"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Correlation",
+        "translations": [
+            "تَعالُق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Correspondence",
+        "translations": [
+            "تلاؤم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Correspondent",
+        "translations": [
+            "متوائم",
+            "موائم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Corrupt",
+        "translations": [
+            "فاسد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cos",
+        "translations": [
+            "جتا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cost",
+        "translations": [
+            "كلفة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cost control callback",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Count",
+        "translations": [
+            "تَعْداد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Countable",
+        "translations": [
+            "قابل للتعداد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Counted",
+        "translations": [
+            "معدود"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Counting records",
+        "translations": [
+            "تسجيلات العدً"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Country code",
+        "translations": [
+            "رمز البلد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Coupling",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Coupon",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Courseware",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Covariance",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "CPU",
+        "translations": [
+            "معالج"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Crack",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Crash",
+        "translations": [
+            "انهيار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Crash dump",
+        "translations": [
+            "تفريغ إنهياري"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Crawler",
+        "translations": [
+            "داب",
+            "زاحف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Create",
+        "translations": [
+            "إنشاء"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Creation",
+        "translations": [
+            "إنشاء"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Credential",
+        "translations": [
+            "إعتماد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Credential cache",
+        "translations": [
+            "خابية إعتمادية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Credits",
+        "translations": [
+            "إشادات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Creeping featurism",
+        "translations": [
+            "إسهال الميزات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Crisp",
+        "translations": [
+            "مُتَقَصِّف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Critereon",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Criteria",
+        "translations": [
+            "معيار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Criteria range",
+        "translations": [
+            "مجال المواصفات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Criterion",
+        "translations": [
+            "مِحك"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Critical error",
+        "translations": [
+            "خطأ حرج"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Critical section",
+        "translations": [
+            "جِزء حرِج"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cron",
+        "translations": [
+            "الدورية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Crop",
+        "translations": [
+            "اقتصاص"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cross-assembler",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cross compilation",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cross-compiler",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cross-device link",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Crossed",
+        "translations": [
+            "تصالب",
+            "تقاطع"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cross-fade",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Crossfade",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cross-fading",
+        "translations": [
+            "خفوت"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Crosshair",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cross-over",
+        "translations": [
+            "معبر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cross-platform",
+        "translations": [
+            "متعدد المنصات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cross-reference",
+        "translations": [
+            "إحالة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cruft",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cruft together",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Crumb",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Crypt",
+        "translations": [
+            "تشفير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cryptanalysis",
+        "translations": [
+            "تحليل التعمية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cryptography",
+        "translations": [
+            "علم التعمية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cryptology",
+        "translations": [
+            "علم التشفير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "CSS",
+        "translations": [
+            "CSS"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Ctrl",
+        "translations": [
+            "Ctrl"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cube",
+        "translations": [
+            "مكعّب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cubing",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cumulative",
+        "translations": [
+            "تراكمي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "CUPS",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Curly bracket",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Current",
+        "translations": [
+            "حالي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Current directory",
+        "translations": [
+            "الدليل الحالي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Current session",
+        "translations": [
+            "الجلسة الحالية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Current working",
+        "translations": [
+            "الأشغال الجارية",
+            "الأعمال الجارية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Curried function",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Currying",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cursor",
+        "translations": [
+            "مُؤشر (الفأرة)"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cursor keys",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cursor plane",
+        "translations": [
+            "سطح المنزلق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Curve",
+        "translations": [
+            "منحنية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Custom",
+        "translations": [
+            "مخصص"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Customization",
+        "translations": [
+            "تخصيص"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Customize",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Custom window",
+        "translations": [
+            "النافذة الإصطلاحية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cut",
+        "translations": [
+            "قص"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cut and paste",
+        "translations": [
+            "قص والصق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cut buffer",
+        "translations": [
+            "صِوان القصً"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cutover",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cut-through switching",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cyber",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cyberbunny",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cybercafe",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cybernetics",
+        "translations": [
+            "التحكم الآلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cyberspace",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cyber-squatting",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cyborg",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cycle",
+        "translations": [
+            "دورة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cyclebabble",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cycle crunch",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cycle drought",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cycle of reincarnation",
+        "translations": [
+            "دورة التناسخ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cycle server",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cyclic redundancy check",
+        "translations": [
+            "تدقيق دوري عن الأخطاء"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Cyclic redundancy code",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cyclomatic complexity",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Cylinder",
+        "translations": [
+            "اسطوانة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Daemon",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Daisy chain",
+        "translations": [
+            "سلسلة تعاقبيّة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Daisywheel printer",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Damage",
+        "translations": [
+            "ضرر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Dangling pointer",
+        "translations": [
+            "مؤشر مدلًى"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Dash",
+        "translations": [
+            "شَرطة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Dashboard",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Data",
+        "translations": [
+            "بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data abstraction",
+        "translations": [
+            "تَجريد البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data acquisition",
+        "translations": [
+            "تحصيل (استحصال) معطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Database",
+        "translations": [
+            "قاعدة بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Database administrator",
+        "translations": [
+            "مدير قاعدة معطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Database analyst",
+        "translations": [
+            "محلل قاعدة معطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Database machine",
+        "translations": [
+            "مكنة قاعدة معطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Database management system",
+        "translations": [
+            "نظام تدبير قاعدة المعطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Database manager",
+        "translations": [
+            "مدير قاعدة بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Database normalisation",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Database query language",
+        "translations": [
+            "لغة استعلام قواعد البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Database server",
+        "translations": [
+            "خادم قاعدة معطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data bus",
+        "translations": [
+            "ناقل البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Datacenter manager",
+        "translations": [
+            "مدير مركز البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data channel",
+        "translations": [
+            "قناة البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data communications analyst",
+        "translations": [
+            "محلل مواصلات المعطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data compression",
+        "translations": [
+            "ضغط بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data connection",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Data dictionary",
+        "translations": [
+            "قاموس بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data dictionary file",
+        "translations": [
+            "ملف قاموس بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data driven",
+        "translations": [
+            "مُساق من البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data flow",
+        "translations": [
+            "تدفّق البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Dataflow",
+        "translations": [
+            "تدفًق بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data flow analysis",
+        "translations": [
+            "تحليل تدفًق بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data flow diagram",
+        "translations": [
+            "مخطًط تدفق البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data fork",
+        "translations": [
+            "تشعًب معطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data frame",
+        "translations": [
+            "إطار قاعدة معطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data glove",
+        "translations": [
+            "قفاز بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Datagramt",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Data hierarchy",
+        "translations": [
+            "هرميَّة البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Dataless client",
+        "translations": [
+            "زبون خالي من المعطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Dataless management utility",
+        "translations": [
+            "منفعة تدبير خالية من المعطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data link layer",
+        "translations": [
+            "طبقة وصل المعطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data link level",
+        "translations": [
+            "مستوى وصل المعطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data logger",
+        "translations": [
+            "مسجّل بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data logging",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Data mart",
+        "translations": [
+            "سوق قاعدة معطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data mining",
+        "translations": [
+            "أستغلال البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data model",
+        "translations": [
+            "نموذج المعطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data modeling",
+        "translations": [
+            "نمذجة المعطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data modelling",
+        "translations": [
+            "نمذجة المعطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data packet",
+        "translations": [
+            "رزمة بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data path",
+        "translations": [
+            "مسار بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data processing",
+        "translations": [
+            "معالجة البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data rate",
+        "translations": [
+            "معدل نقل البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data segment",
+        "translations": [
+            "قطعة بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data service",
+        "translations": [
+            "خدمة بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data service unit",
+        "translations": [
+            "وحدة خدمة البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data set",
+        "translations": [
+            "مجموعة بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Dataset",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Data set organization",
+        "translations": [
+            "تنظيم مجموعة البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data striping",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Data structure",
+        "translations": [
+            "بنية البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data transfer bus",
+        "translations": [
+            "مسرى نقل المعطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data transfer rate",
+        "translations": [
+            "معدّل نقل البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data type",
+        "translations": [
+            "نوع البيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Datatype definition",
+        "translations": [
+            "تعريف نوع المعطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data unit",
+        "translations": [
+            "وحدة بيانات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data warehouse",
+        "translations": [
+            "مخزن معطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Data warehousing",
+        "translations": [
+            "خزن المعطيات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Date",
+        "translations": [
+            "تاريخ"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Datum",
+        "translations": [
+            "معطى"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Daughter",
+        "translations": [
+            "سليلة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Daughterboard",
+        "translations": [
+            "لوحة سليلة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Daughtercard",
+        "translations": [
+            "بطاقة سليلة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Day",
+        "translations": [
+            "يوم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Day mode",
+        "translations": [
+            "نهاري النمط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deactivate",
+        "translations": [
+            "بطّل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Dead",
+        "translations": [
+            "عاطل",
+            "ميت"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Dead code",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Deadlock",
+        "translations": [
+            "أزمة",
+            "مأزق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deadly embrace",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Dealer",
+        "translations": [
+            "مُتَّجِر"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Death code",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Deb",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Debianize",
+        "translations": [
+            "دَبيَنة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Debug",
+        "translations": [
+            "تنقيح"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Debugger",
+        "translations": [
+            "منقّح"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Debugging",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Decay",
+        "translations": [
+            "تضاؤل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Dechunker",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Decidability",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Decidable",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Decimal",
+        "translations": [
+            "عشري"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Decimal point",
+        "translations": [
+            "فاصل عُشري"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Decision problem",
+        "translations": [
+            "مشكلة قرار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Decision support",
+        "translations": [
+            "دعم قرار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Decision support database",
+        "translations": [
+            "قاعدة بيانات دعم القرار",
+            "قاعدة معلومات دعم القرار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Decision theory",
+        "translations": [
+            "نظرية القرار"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Declaration",
+        "translations": [
+            "إبلاغ",
+            "علانية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Declarative language",
+        "translations": [
+            "لغة تقريرية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Declare",
+        "translations": [
+            "إدلاء",
+            "إعلان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Decode",
+        "translations": [
+            "فك ترميز"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Decoder",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Decompress",
+        "translations": [
+            "فك ضغط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Decorative",
+        "translations": [
+            "زخرفي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Decrease",
+        "translations": [
+            "تخفيض",
+            "تخفيف",
+            "تقليل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Decrypt",
+        "translations": [
+            "فَك التعمية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Decryption",
+        "translations": [
+            "فك تشفير"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Dedicated line",
+        "translations": [
+            "خطً مُكرًس"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deductive database",
+        "translations": [
+            "قاعدة معطيات إستنتاجية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deductive tableau",
+        "translations": [
+            "لوح إستنتاجي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deep",
+        "translations": [
+            "غميق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deep magic",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "De facto standard",
+        "translations": [
+            "معيار فعلي",
+            "معيار واقعي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Default",
+        "translations": [
+            "مبدئي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Default master",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Default route",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Defect",
+        "translations": [
+            "عيب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Defect analysis",
+        "translations": [
+            "تحليل العلًة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Defect density",
+        "translations": [
+            "كثافة العلل"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deferral",
+        "translations": [
+            "إِرْجاء"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Define",
+        "translations": [
+            "تحديد",
+            "تعريف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Definite clause",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Definite sentence",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Definition",
+        "translations": [
+            "تعريف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Definitional constraint programming",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Deflate",
+        "translations": [
+            "منكمش"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deflate compression",
+        "translations": [
+            "ضغط منكمش"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deforestation",
+        "translations": [
+            "إجتثاث الغابة",
+            "إزالة الغابة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Defragment",
+        "translations": [
+            "إزالة التشظية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Defunct process",
+        "translations": [
+            "إجراء فان",
+            "إجراء ميت"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Degree",
+        "translations": [
+            "درجة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Degrees",
+        "translations": [
+            "درجات"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Degrees of freedom",
+        "translations": [
+            "درجات الحرية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deinstallation",
+        "translations": [
+            "إزالة التثبيت",
+            "فك التثبيت"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deinterlace",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Dejagging",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Delay",
+        "translations": [
+            "تأخير",
+            "مهلة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Delayed control-transfer",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Delay instruction",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Delay slot",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Delegation",
+        "translations": [
+            "بعثة",
+            "نيابة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Delete",
+        "translations": [
+            "حذف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deletia",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Deletion",
+        "translations": [
+            "حذف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Delimiter",
+        "translations": [
+            "مُحِد"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deliverable",
+        "translations": [
+            "مُسْتَلَم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Delivery",
+        "translations": [
+            "تسليم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Delta",
+        "translations": [
+            "دَال"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Delta conversion",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Delta reduction",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Demand",
+        "translations": [
+            "ألضرورة",
+            "المطلب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Demand driven",
+        "translations": [
+            "منساق بلضرورة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Demand paged",
+        "translations": [
+            "صفحيً الضرورة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Demand paging",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Demo",
+        "translations": [
+            "عرض"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Demodulate",
+        "translations": [
+            "فكً الترنيم",
+            "كشف الترنيم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Demodulation",
+        "translations": [
+            "كشف الترنيم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Demo mode",
+        "translations": [
+            "نمط العرض التوضيحي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Demote",
+        "translations": [
+            "حط من الرتبة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Demo version",
+        "translations": [
+            "اصدارة العرض التوضيحي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Denominator",
+        "translations": [
+            "قاسم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Denotational semantics",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Deny",
+        "translations": [
+            "رفض"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Depeditate",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Dependability",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Dependable software",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Dependancy",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Dependence",
+        "translations": [
+            "ارتباط",
+            "تبعية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Dependency",
+        "translations": [
+            "اعتمادية"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deprecate",
+        "translations": [
+            "أدان"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deprecated",
+        "translations": [
+            "مهجور"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deprecation",
+        "translations": [
+            "إِدَانَة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Depth",
+        "translations": [
+            "عمق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Depth-first search",
+        "translations": [
+            "البحث بالعمق أولا"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Dereference",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Derivative",
+        "translations": [
+            "مشتق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Derived",
+        "translations": [
+            "مُشتق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Derived class",
+        "translations": [
+            "فئة مشتقة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Derived type",
+        "translations": [
+            "نوع مشتق"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Desaturate",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Descender",
+        "translations": [
+            "مخسوف",
+            "هابط"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Descending",
+        "translations": [
+            "تناقصي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Descending sort",
+        "translations": [
+            "ترتيب تنازلي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Descent function",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Description",
+        "translations": [
+            "الوصف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Descriptor",
+        "translations": [
+            "واصف"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deselect",
+        "translations": [
+            "عدم انتقاء"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Design",
+        "translations": [
+            "تصميم"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Design pattern",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Design recovery",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Desk",
+        "translations": [
+            "مكتب",
+            "مِنضدة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Desk check",
+        "translations": [
+            "فحص مكتبي"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Deskside",
+        "translations": [
+            "جانب المكتب",
+            "جانب المنضدة"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Desktop",
+        "translations": [
+            "سطح مكتب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Desktop background",
+        "translations": [
+            "خلفية سطح المكتب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Desktop database",
+        "translations": [
+            "قاعدة بيانات سطح المكتب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Desktop environment",
+        "translations": [
+            "محيط سطح المكتب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Desktop manager",
+        "translations": [],
+        "is_checked": false
+    },
+    {
+        "word": "Desktop publisher",
+        "translations": [
+            "محرر سطح المكتب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Desktop publishing",
+        "translations": [
+            "نشر عبر سطح المكتب"
+        ],
+        "is_checked": false
+    },
+    {
+        "word": "Destination",
+        "translations": [
+            "مقصد"
+        ],
+        "is_checked": false
+    }
 ]


### PR DESCRIPTION
'Abort' has reached the minimum translations limit
The New default Translation is: 'إجهاض'

These are the 5 most commoun translations:
0. 'إجهاض'
1. 'مرحبا'
2. 'تجربة'
3. 'كمان'
4. 'آ{تش'

To change the default translation, write: /set-default NumberOfTranslation
To delete Specific translation, write: /delete NumberOfTranslation